### PR TITLE
Add shapefile libraries via CDN

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -13,8 +13,9 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.css"/>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
     
-    <script src="lib/proj4.js"></script>
-    <script src="lib/shpwrite.js"></script>
+    <!-- Chargement des librairies depuis CDN -->
+    <script src="https://cdn.jsdelivr.net/npm/proj4@2.19.3/dist/proj4.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/shp-write@0.3.2/shpwrite.js"></script>
     
     <script defer src="ui.js"></script>
     <script defer src="biblio-patri.js"></script>


### PR DESCRIPTION
## Summary
- load `proj4` and `shp-write` from CDN so the shapefile download button works

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7491814c832caf8aef7a5344d27b