### PR TITLE
Enable shapefile download in Lambert 93

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -13,8 +13,8 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.css"/>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
     
-    <script src="lib/proj4.js"></script>
-    <script src="lib/shpwrite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/proj4@2.9.0/dist/proj4.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/shp-write@0.3.2/shpwrite.js"></script>
     
     <script defer src="ui.js"></script>
     <script defer src="biblio-patri.js"></script>

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -668,7 +668,12 @@ const initializeSelectionMap = (coords) => {
     const downloadShapefile = () => {
         if (!currentShapefileData) return;
         try {
-            shpwrite.download(currentShapefileData, { folder: 'patrimonial_data', types: { point: 'occurrences' } });
+            const lambert93Prj = 'PROJCS["RGF93 / Lambert-93",GEOGCS["RGF93",DATUM["Reseau_Geodesique_Francais_1993",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6171"]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433],AUTHORITY["EPSG","4171"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",49],PARAMETER["standard_parallel_2",44],PARAMETER["latitude_of_origin",46.5],PARAMETER["central_meridian",3],PARAMETER["false_easting",700000],PARAMETER["false_northing",6600000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","2154"]]';
+            shpwrite.download(currentShapefileData, {
+                folder: 'patrimonial_data',
+                types: { point: 'occurrences' },
+                prj: lambert93Prj
+            });
         } catch (e) {
             if (typeof showNotification === 'function') {
                 showNotification("Erreur lors de la génération du shapefile", 'error');

--- a/sw.js
+++ b/sw.js
@@ -20,8 +20,6 @@ const CORE_ASSETS = [
    "./contexte.js",
    "./biblio-patri.js",
    "./style.css",
-   "./lib/proj4.js",
-   "./lib/shpwrite.js",
    "./assets/viewer_app.js",
    "./manifest.json",
    "./assets/flora_gallica_toc.json",


### PR DESCRIPTION
## Summary
- load proj4 and shp-write from CDN in `biblio-patri.html`
- ensure shapefile export includes Lambert‑93 `.prj` file
- stop precaching removed local libraries in `sw.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e77db41e8832c8fb4107434af831c