### PR TITLE
Fix PlantNet proxy IP

### DIFF
--- a/netlify/functions/api-proxy.js
+++ b/netlify/functions/api-proxy.js
@@ -33,8 +33,17 @@ exports.handler = async (event) => {
                 upstreamOptions = {
                     method: 'POST',
                     body: form,
-                    headers: form.getHeaders()
+                    headers: {
+                        ...form.getHeaders(),
+                        'User-Agent': event.headers['user-agent'] || 'PlantouilleApp/1.0'
+                    }
                 };
+                const forwardedFor = event.headers['x-forwarded-for'] ||
+                                   event.headers['client-ip'] ||
+                                   event.headers['x-nf-client-connection-ip'];
+                if (forwardedFor) {
+                    upstreamOptions.headers['X-Forwarded-For'] = forwardedFor;
+                }
                 break;
 
             case 'gemini':


### PR DESCRIPTION
## Summary
- forward the original client IP address and user agent to the PlantNet API

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9a5c3a9c832c85de4720b2bda83d