### PR TITLE
Improve PlantNet error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ const TTS_API_KEY    = "your-text-to-speech-key";
 
 These keys are required for PlantNet image identification, Gemini summaries and Google TTS audio synthesis.
 
+**Troubleshooting PlantNet**: if the API responds with `remote IP not allowed`, your key is restricted to specific IP addresses.
+When testing locally you must run the Netlify proxy functions (`netlify dev`) from an authorized host or allow the IP of your deployment in the PlantNet dashboard.
+
 ## Running the application locally
 
 1. Serve the project from a local HTTP server (for example using `npx serve` or `python3 -m http.server`).

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -96,4 +96,19 @@ describe('api helpers', () => {
     const list = await ctx.getSimilarSpeciesFromGemini('Abies alba');
     expect(list).toEqual(['Abies nordmanniana','Abies pinsapo']);
   });
+
+  test('apiFetch rewrites PlantNet IP error', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ error: 'remote IP not allowed' })
+    });
+    const ctx = loadApp({ fetch: fetchMock });
+    const data = await ctx.apiFetch('plantnet', {});
+    expect(ctx.showNotification).toHaveBeenCalledWith(
+      "Accès PlantNet refusé : vérifiez que l'IP autorisée correspond à votre hébergement.",
+      'error'
+    );
+    expect(data).toBeNull();
+  });
 });

--- a/app.js
+++ b/app.js
@@ -296,7 +296,10 @@ async function apiFetch(target, payload) {
 
         const responseData = await res.json();
         if (!res.ok) {
-            const errorMessage = responseData.error || `Erreur API (${res.status})`;
+            let errorMessage = responseData.error || `Erreur API (${res.status})`;
+            if (/remote IP not allowed/i.test(errorMessage) || /IP non autorisée/i.test(errorMessage)) {
+                errorMessage = "Accès PlantNet refusé : vérifiez que l'IP autorisée correspond à votre hébergement.";
+            }
             throw new Error(errorMessage);
         }
         return responseData;

--- a/netlify/functions/api-proxy.js
+++ b/netlify/functions/api-proxy.js
@@ -67,6 +67,13 @@ exports.handler = async (event) => {
 
         const response = await fetch(upstreamUrl, upstreamOptions);
         const responseData = await response.json();
+        if (!response.ok && responseData && /remote IP not allowed/i.test(responseData.message || responseData.error)) {
+            // PlantNet renvoie cette erreur lorsque la clé n'est pas autorisée pour l'adresse IP
+            return {
+                statusCode: 403,
+                body: JSON.stringify({ error: 'PlantNet: IP non autorisée pour cette clé' })
+            };
+        }
 
         if (!response.ok) {
             console.error(`Upstream API error for target "${target}":`, responseData);


### PR DESCRIPTION
## Summary
- detect PlantNet 'remote IP not allowed' errors in the proxy
- show a friendlier notification in `apiFetch`
- mention IP restriction in the README
- test new behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9bfab9d8832c8bd6b4fe36329988