### PR TITLE
Modernize dark theme for all pages

### DIFF
--- a/contexte.html
+++ b/contexte.html
@@ -13,8 +13,8 @@
    <script defer src="sw-register.js"></script>
    <style>
       /* Couleurs plus "écologiques" pour une identité visuelle claire */
-      :root{ --primary:#388e3c; --bg:#000000; --card:#ffffff; --border:#e0e0e0; --text:#ffffff; --max-width:600px; }
-      html[data-theme="dark"]{ --bg:#000000; --card:#262b2f; --border:#333; --text:#ececec; }
+      :root{ --primary:#388e3c; --bg:#333333; --card:#444444; --border:#555555; --text:#ffffff; --max-width:600px; }
+      html[data-theme="dark"]{ --bg:#333333; --card:#444444; --border:#555555; --text:#ffffff; }
       *{box-sizing:border-box;}
       body{
          background:var(--bg);
@@ -113,7 +113,7 @@
       }
       
       @media (prefers-color-scheme:dark) {
-         :root{--bg:#181a1b;--card:#262b2f;--border:#333;--text:#ececec}
+         :root{--bg:#333333;--card:#444444;--border:#555555;--text:#ffffff}
          .coordinates-display { background: rgba(46, 125, 50, 0.2); }
          .map-instruction { background: rgba(255, 255, 255, 0.15); }
       }

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
    <script defer src="app.js"></script>
    <script defer src="sw-register.js"></script>
    <style>
-      :root{ --primary:#388e3c; --bg:#f6f9fb; --card:#ffffff; --border:#e0e0e0; --text:#202124; }
-      html[data-theme="dark"]{ --bg:#181a1b; --card:#262b2f; --border:#333; --text:#ececec; }
+      :root{ --primary:#388e3c; --bg:#333333; --card:#444444; --border:#555555; --text:#ffffff; }
+      html[data-theme="dark"]{ --bg:#333333; --card:#444444; --border:#555555; --text:#ffffff; }
       *{box-sizing:border-box;}
       
       /* NOUVEAU : Styles pour la navigation par onglets */
@@ -92,7 +92,7 @@
          body.home #main-content{padding-top:5vh;}
       }
       th,td{ padding: 8px 6px; border-bottom:1px solid var(--border); word-wrap: break-word; vertical-align: top; }
-      th{background:#f5f5f5;color:#000;font-weight:600;text-align:left}
+      th{background:#555555;color:#ffffff;font-weight:600;text-align:left}
       tr:last-child td{border-bottom:none}
       tbody tr:nth-child(odd){background-color:#444;}
       .col-nom-latin { width: 20%; }
@@ -206,11 +206,11 @@
          background-color: #fb8c00;
       }
 
-      @media (prefers-color-scheme:dark){ 
-         :root{--bg:#181a1b;--card:#262b2f;--border:#333;--text:#ececec} 
+      @media (prefers-color-scheme:dark){
+         :root{--bg:#333333;--card:#444444;--border:#555555;--text:#ffffff}
          .tabs-container { background: var(--card); }
          .tab:hover { background: rgba(56, 142, 60, 0.2); }
-         table,details{border-color:#333} th{background:#30363c;color:#ececec} tbody tr:nth-child(odd){background-color:#444;} body.home .upload-btn.logo-btn span { color: var(--text); } .option-container { background-color: rgba(38, 43, 47, 0.8); } #multi-image-list-area .image-organ-item { background-color: var(--card); border-color: var(--border); } #multi-image-list-area select { background-color: #333; color: var(--text); } .col-nom-latin .score { color:#ccc; } .col-criteres { color: #ccc; } .col-physionomie { color:#ccc; } .col-phenologie { color:#ccc; } #multi-image-list-area .delete-file-btn { color: #ff6b6b; } #multi-image-list-area .delete-file-btn:hover { color: #ff8787; } .search-inline input[type="search"] { background-color: #fff; color: #000; border-color: #555; }
+         table,details{border-color:#333} th{background:#555555;color:#ffffff} tbody tr:nth-child(odd){background-color:#444;} body.home .upload-btn.logo-btn span { color: var(--text); } .option-container { background-color: rgba(38, 43, 47, 0.8); } #multi-image-list-area .image-organ-item { background-color: var(--card); border-color: var(--border); } #multi-image-list-area select { background-color: #333; color: var(--text); } .col-nom-latin .score { color:#ccc; } .col-criteres { color: #ccc; } .col-physionomie { color:#ccc; } .col-phenologie { color:#ccc; } #multi-image-list-area .delete-file-btn { color: #ff6b6b; } #multi-image-list-area .delete-file-btn:hover { color: #ff8787; } .search-inline input[type="search"] { background-color: #fff; color: #000; border-color: #555; }
          .col-image { width: 80px; }
       }
    </style>

--- a/organ.html
+++ b/organ.html
@@ -12,8 +12,8 @@
   <script defer src="app.js"></script>
   <script defer src="sw-register.js"></script>
   <style>
-    :root{--primary:#388e3c;--bg:#f6f9fb;--card:#ffffff;--border:#e0e0e0;--text:#202124}
-    html[data-theme="dark"]{--bg:#181a1b;--card:#262b2f;--border:#333;--text:#ececec}
+    :root{--primary:#388e3c;--bg:#333333;--card:#444444;--border:#555555;--text:#ffffff}
+    html[data-theme="dark"]{--bg:#333333;--card:#444444;--border:#555555;--text:#ffffff}
     *{box-sizing:border-box;}
     /* MODIFICATION : Le body prend toute la largeur, suppression de max-width et margin:auto */
     body{background:var(--bg);color:var(--text);font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;margin:0;padding:1.2rem;}
@@ -35,7 +35,7 @@
     table{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--border);border-radius:12px;box-shadow:0 2px 6px rgba(0,0,0,.05);margin-bottom:1.2rem;table-layout:auto;}
     
     th,td{padding:8px 10px;border-bottom:1px solid var(--border);vertical-align:middle;word-wrap:break-word;}
-    th{background:#f5f5f5;color:#000;font-weight:600;text-align:left}
+    th{background:#555555;color:#ffffff;font-weight:600;text-align:left}
     tr:last-child td{border-bottom:none}
     tbody tr:nth-child(odd){background-color:#444;}
     td a{color:var(--primary);text-decoration:none}
@@ -181,7 +181,7 @@
     summary:hover{background:rgba(0,0,0,.04);}
     .iframe-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:12px;padding:12px;}
     iframe{width:100%;height:280px;border:none;border-radius:4px;}
-    @media (prefers-color-scheme:dark){:root{--bg:#181a1b;--card:#262f;--border:#333;--text:#ececec}table,details{border-color:#333}th{background:#30363c;color:#ececec} tbody tr:nth-child(odd){background-color:#444;} .search-inline input[type="search"]{background-color:#fff;color:#000;border-color:#555;}}
+    @media (prefers-color-scheme:dark){:root{--bg:#333333;--card:#444444;--border:#555555;--text:#ffffff}table,details{border-color:#333}th{background:#555555;color:#ffffff} tbody tr:nth-child(odd){background-color:#444;} .search-inline input[type="search"]{background-color:#fff;color:#000;border-color:#555;}}
     .select-toggle-btn{background:none;border:none;cursor:pointer;color:var(--primary);font-size:0.9rem;padding:0;}
     .select-toggle-btn:hover{text-decoration:underline;}
   </style>

--- a/style.css
+++ b/style.css
@@ -1,16 +1,16 @@
 :root {
     --primary: #388e3c;
-    --bg: #f6f9fb;
-    --card: #ffffff;
-    --border: #e0e0e0;
-    --text: #202124;
+    --bg: #333333;
+    --card: #444444;
+    --border: #555555;
+    --text: #ffffff;
     --max-width: 900px;
 }
 html[data-theme="dark"] {
-    --bg: #181a1b;
-    --card: #262b2f;
-    --border: #333;
-    --text: #ececec;
+    --bg: #333333;
+    --card: #444444;
+    --border: #555555;
+    --text: #ffffff;
 }
 
 *, *::before, *::after { box-sizing: border-box; }
@@ -139,10 +139,10 @@ th, td {
 }
 th {
     font-weight: 600;
-    background: #f5f5f5;
-    color: #202124;
+    background: #555555;
+    color: #ffffff;
 }
-html[data-theme="dark"] th { background: #333; color: #ececec; }
+html[data-theme="dark"] th { background: #555555; color: #ffffff; }
 tbody tr:last-child td { border-bottom: none; }
 tbody tr:hover { background-color: rgba(198,40,40,0.05); cursor: pointer; }
 html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15); }

--- a/viewer.html
+++ b/viewer.html
@@ -8,7 +8,8 @@
         body, html {
             margin: 0;
             padding: 0;
-            background-color: #f0f0f0;
+            background-color: #333333;
+            color: #ffffff;
             font-family: sans-serif;
         }
         #pdf-viewer {


### PR DESCRIPTION
## Summary
- update global color variables to a dark grey theme
- apply the same dark palette across index, context, organ and viewer pages
- tweak table headers for legibility

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb071eb50832c8d0c0ff1e48d0d41