### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="fr" data-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -20,6 +20,7 @@
     <script defer src="ui.js"></script>
     <script defer src="biblio-patri.js"></script>
     <script defer src="sw-register.js"></script>
+    <script defer src="theme.js"></script>
 </head>
 <body>
     <nav class="tabs-container">
@@ -28,6 +29,7 @@
             <button class="tab" onclick="window.location.href='contexte.html'">Contexte éco</button>
             <button class="tab active">Biblio Patri</button>
         </div>
+        <button class="theme-toggle" aria-label="Changer le thème"></button>
     </nav>
     <div class="main-content">
         <h1>Analyse des Espèces Patrimoniales à Proximité</h1>

--- a/contexte.html
+++ b/contexte.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="fr">
+<html lang="fr" data-theme="dark">
 <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -11,6 +11,7 @@
    <script defer src="ui.js"></script>
    <script defer src="contexte.js"></script>
    <script defer src="sw-register.js"></script>
+   <script defer src="theme.js"></script>
    <link rel="stylesheet" href="style.css">
    <style>
       /* Couleurs plus "écologiques" pour une identité visuelle claire */
@@ -124,6 +125,7 @@
          <button class="tab active">🌿 Contexte éco</button>
          <button class="tab" onclick="window.location.href='biblio-patri.html'">Biblio Patri</button>
       </div>
+      <button class="theme-toggle" aria-label="Changer le thème"></button>
    </nav>
 
    <div class="main-content">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="fr">
+<html lang="fr" data-theme="dark">
 <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -9,6 +9,7 @@
    <script defer src="ui.js"></script>
    <script defer src="app.js"></script>
    <script defer src="sw-register.js"></script>
+   <script defer src="theme.js"></script>
    <link rel="stylesheet" href="style.css">
    <style>
       *{box-sizing:border-box;}
@@ -220,6 +221,7 @@
            <button class="tab" onclick="window.location.href='contexte.html'">Contexte éco</button>
            <button class="tab" onclick="window.location.href='biblio-patri.html'">Biblio Patri</button>
        </div>
+       <button class="theme-toggle" aria-label="Changer le thème"></button>
    </nav>
 
    <div id="main-content">

--- a/organ.html
+++ b/organ.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="fr">
+<html lang="fr" data-theme="dark">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -11,6 +11,7 @@
   <script defer src="ui.js"></script>
   <script defer src="app.js"></script>
   <script defer src="sw-register.js"></script>
+  <script defer src="theme.js"></script>
   <link rel="stylesheet" href="style.css">
   <style>
     *{box-sizing:border-box;}
@@ -188,6 +189,7 @@
 <body class="home">
   <div style="display:flex;justify-content:space-between;align-items:center;">
     <h1 style="margin:0">Plante App</h1>
+    <button class="theme-toggle" aria-label="Changer le thème"></button>
   </div>
   <img id="preview" alt="Prévisualisation">
   <div id="organ-choice">

--- a/style.css
+++ b/style.css
@@ -12,6 +12,12 @@ html[data-theme="dark"] {
     --border: #555555;
     --text: #ffffff;
 }
+html[data-theme="light"] {
+    --bg: #ffffff;
+    --card: #f8f8f8;
+    --border: #cccccc;
+    --text: #000000;
+}
 
 *, *::before, *::after { box-sizing: border-box; }
 body {
@@ -94,6 +100,15 @@ h1 {
 }
 .action-button:hover { background: #2e7d32; }
 
+.theme-toggle {
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-radius: 4px;
+    padding: 0.3rem 0.6rem;
+    cursor: pointer;
+}
+
 .status-container {
     text-align: center;
     margin: 1rem 0;
@@ -143,9 +158,11 @@ th {
     color: #ffffff;
 }
 html[data-theme="dark"] th { background: #555555; color: #ffffff; }
+html[data-theme="light"] th { background: #eeeeee; color: #000000; }
 tbody tr:last-child td { border-bottom: none; }
 tbody tr:hover { background-color: rgba(198,40,40,0.05); cursor: pointer; }
 html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15); }
+html[data-theme="light"] tbody tr:hover { background-color: rgba(198,40,40,0.1); }
 
 .legend-color {
     display: inline-block;

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.documentElement;
+  const saved = localStorage.getItem('theme');
+  const initial = saved === 'light' ? 'light' : 'dark';
+  root.setAttribute('data-theme', initial);
+
+  document.querySelectorAll('.theme-toggle').forEach(btn => {
+    btn.textContent = initial === 'dark' ? '☀️' : '🌙';
+    btn.addEventListener('click', () => {
+      const current = root.getAttribute('data-theme');
+      const next = current === 'dark' ? 'light' : 'dark';
+      root.setAttribute('data-theme', next);
+      localStorage.setItem('theme', next);
+      document.querySelectorAll('.theme-toggle').forEach(b => {
+        b.textContent = next === 'dark' ? '☀️' : '🌙';
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a theme toggle script with local storage persistence
- support light theme in CSS
- add toggle buttons to all main pages
- load `theme.js` on each page

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efba8a714832c9ee2dd5ef8cc914c