### PR TITLE
Change default map layer to OpenTopoMap

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -660,6 +660,10 @@ const initializeSelectionMap = (coords) => {
             attribution: '© OpenStreetMap contributors'
         });
 
+        const topoMap = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+            attribution: 'Map data: © OpenStreetMap contributors, SRTM | Map style: © OpenTopoMap (CC-BY-SA)'
+        });
+
         const satelliteMap = L.tileLayer(
             'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
             {
@@ -674,7 +678,7 @@ const initializeSelectionMap = (coords) => {
         obsMap = L.map(obsMapContainer, {
             center: [45.1885, 5.7245],
             zoom: 12,
-            layers: [planMap]
+            layers: [topoMap]
         });
 
         // Centrer la carte sur la position de l'utilisateur si disponible
@@ -692,6 +696,7 @@ const initializeSelectionMap = (coords) => {
         observationsLayerGroup = L.layerGroup().addTo(obsMap);
 
         const baseMaps = {
+            "OpenTopoMap": topoMap,
             "Plan": planMap,
             "Satellite": satelliteMap
         };


### PR DESCRIPTION
## Summary
- default map layer for "Observations locales" is now OpenTopoMap

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f13605a64832c8cd4249c988f25d2