### PR TITLE
Remove help text from bibliopatri

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -580,7 +580,6 @@ const initializeSelectionMap = (coords) => {
             center = { latitude: coords.latitude, longitude: coords.longitude };
         } catch (e) {}
         initializeSelectionMap(center);
-        setStatus('Appuyez longuement ou faites un clic droit sur la carte pour choisir un lieu.', false);
         let pressTimer;
         const cleanup = () => {
             map.off('contextmenu', onContextMenu);


### PR DESCRIPTION
## Summary
- remove the long press hint in `biblio-patri.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f16d5a9ec832cb4cbd5f2f6af78a0