### PR TITLE
Improve mobile layout in biblio patrimonial page

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -41,19 +41,11 @@
                     <input type="text" id="address-input" placeholder="Saisir une adresse, une ville, un lieu...">
                     <button id="search-address-btn" class="action-button">🔍 Rechercher</button>
                 </div>
-                <div class="search-group">
+                <div class="button-grid">
                     <button id="use-geolocation-btn" class="action-button">📍 Ma position</button>
-                </div>
-                <div class="search-group">
                     <button id="select-on-map-btn" class="action-button">🗺️ Choisir sur la carte</button>
-                </div>
-                <div class="search-group">
                     <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
-                </div>
-                <div class="search-group">
                     <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
-                </div>
-                <div class="search-group">
                     <button id="toggle-labels-btn" class="action-button">Masquer les étiquettes</button>
                 </div>
             </div>
@@ -71,16 +63,10 @@
 
         <div id="observations-tab" class="tab-content" style="display:none;">
             <div class="search-controls">
-                <div class="search-group">
+                <div class="button-grid">
                     <button id="obs-geoloc-btn" class="action-button">📍 Ma position</button>
-                </div>
-                <div class="search-group">
                     <button id="obs-draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
-                </div>
-                <div class="search-group">
                     <button id="obs-toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
-                </div>
-                <div class="search-group">
                     <button id="obs-toggle-labels-btn" class="action-button">Masquer les étiquettes</button>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -88,6 +88,13 @@ h1 {
 }
 .search-group.address-group { flex-basis: 100%; }
 
+.button-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.5rem;
+    width: 100%;
+}
+
 #address-input {
     flex: 1;
     padding: 0.6rem;
@@ -184,6 +191,9 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
     .action-button {
         padding: 0.5rem;
         font-size: 0.9rem;
+    }
+    .button-grid {
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
     }
 }
 /* Style pour la navigation principale (issue de l'app cible) */


### PR DESCRIPTION
## Summary
- reorganize search buttons on biblio-patri.html for a tighter layout
- introduce a grid layout for action buttons in style.css
- adapt grid on narrow screens

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f18370134832cbcba37fc776e2ead