### PR TITLE
Improve species details button reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,5 +125,5 @@ This launches the Jest test suite which validates the helper utilities and the
   or right click, making accidental selections on mobile devices less likely.
 
 
-- The patrimonial analysis page now provides a "Voir le détail des espèces patri" button to list every found species on the organ page.
+- The patrimonial analysis page now provides a "Voir le détail des espèces patri" button to list every found species on the organ page. The underlying logic was reinforced so the button works reliably even if the map is still loading.
 - Buttons on both patrimonial maps toggle label visibility; labels start slightly translucent for readability.

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -379,8 +379,10 @@ const initializeSelectionMap = (coords) => {
             return;
         }
         setStatus(`${Object.keys(patrimonialMap).length} espèce(s) patrimoniale(s) trouvée(s). Lancement de l'étape 4/4 : cartographie détaillée...`);
+
+        const allSpeciesList = Object.keys(patrimonialMap).sort();
         const tableBody = document.createElement('tbody');
-        Object.keys(patrimonialMap).sort().forEach((speciesName, index) => {
+        allSpeciesList.forEach((speciesName, index) => {
             const color = SPECIES_COLORS[index % SPECIES_COLORS.length];
             const row = tableBody.insertRow();
             row.dataset.species = speciesName;
@@ -446,9 +448,9 @@ const initializeSelectionMap = (coords) => {
         });
 
         detailsBtn.addEventListener('click', () => {
-            // Use the global list of species to avoid issues with DOM queries
-            // when the table is refreshed or modified.
-            const names = Array.from(allPatrimonialSpecies);
+            // Use the pre‑computed list from the analysis; fall back to the
+            // global array if it has been populated later on.
+            const names = allSpeciesList.length ? allSpeciesList : Array.from(allPatrimonialSpecies);
             if (names.length) {
                 sessionStorage.setItem('speciesQueryNames', JSON.stringify(names));
                 window.location.href = 'organ.html';


### PR DESCRIPTION
## Summary
- capture species list before building the table on the patrimonial analysis page
- use this list when navigating to `organ.html` to avoid timing issues
- document the improved reliability in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7de3897c832ca2bafe036ff7be04