### PR TITLE
Remove tutorial hints on biblio map tabs

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -170,7 +170,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (!response.ok) throw new Error("Le référentiel BDCstatut.csv est introuvable.");
             const csvText = await response.text();
             rulesByTaxonIndex = indexRulesFromCSV(csvText);
-            setStatus("Prêt. Choisissez une méthode de recherche.");
+            setStatus("");
             console.log(`Référentiel chargé, ${rulesByTaxonIndex.size} taxons indexés.`);
         } catch (error) {
             setStatus(`Erreur critique au chargement : ${error.message}`);
@@ -648,7 +648,7 @@ const initializeSelectionMap = (coords) => {
             observationsTabBtn.classList.add('active');
             stopLocationTracking();
             initializeObservationMap();
-            obsStatusDiv.textContent = "Faites un clic droit sur la carte ou maintenez un appui long pour choisir un endroit. Une confirmation s'affichera.";
+            obsStatusDiv.textContent = "";
         }
     };
 


### PR DESCRIPTION
## Summary
- remove help text on the patrimonial map
- clear help text when switching to observation map

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7e748ef0832cb71f9bb4225f990f