### PR TITLE
Add geolocated status analysis

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,6 +27,54 @@ const nonPatrimonialLabels = new Set([
     "Liste des espèces végétales sauvages pouvant faire l'objet d'une réglementation préfectorale dans les départements d'outre-mer : Article 1"
 ]);
 const nonPatrimonialRedlistCodes = new Set(['LC', 'DD', 'NA', 'NE']);
+const HABITATS_DIRECTIVE_CODES = new Set(['CDH1', 'CDH2', 'CDH4', 'CDH5']);
+const OLD_REGIONS_TO_DEPARTMENTS = {
+  'Alsace': ['67', '68'], 'Aquitaine': ['24', '33', '40', '47', '64'],
+  'Auvergne': ['03', '15', '43', '63'], 'Basse-Normandie': ['14', '50', '61'],
+  'Bourgogne': ['21', '58', '71', '89'], 'Champagne-Ardenne': ['08', '10', '51', '52'],
+  'Franche-Comté': ['25', '39', '70', '90'], 'Haute-Normandie': ['27', '76'],
+  'Languedoc-Roussillon': ['11', '30', '34', '48', '66'], 'Limousin': ['19', '23', '87'],
+  'Lorraine': ['54', '55', '57', '88'], 'Midi-Pyrénées': ['09', '12', '31', '32', '46', '65', '81', '82'],
+  'Nord-Pas-de-Calais': ['59', '62'], 'Picardie': ['02', '60', '80'],
+  'Poitou-Charentes': ['16', '17', '79', '86'], 'Rhône-Alpes': ['01', '07', '26', '38', '42', '69', '73', '74']
+};
+const ADMIN_NAME_TO_CODE_MAP = {
+  "France": "FR", "Ain": "01", "Aisne": "02", "Allier": "03",
+  "Alpes-de-Haute-Provence": "04", "Hautes-Alpes": "05",
+  "Alpes-Maritimes": "06", "Ardèche": "07", "Ardennes": "08", "Ariège": "09",
+  "Aube": "10", "Aude": "11", "Aveyron": "12", "Bouches-du-Rhône": "13",
+  "Calvados": "14", "Cantal": "15", "Charente": "16", "Charente-Maritime": "17",
+  "Cher": "18", "Corrèze": "19", "Corse-du-Sud": "2A", "Haute-Corse": "2B",
+  "Côte-d'Or": "21", "Côtes-d'Armor": "22", "Creuse": "23", "Dordogne": "24",
+  "Doubs": "25", "Drôme": "26", "Eure": "27", "Eure-et-Loir": "28",
+  "Finistère": "29", "Gard": "30", "Haute-Garonne": "31", "Gers": "32",
+  "Gironde": "33", "Hérault": "34", "Ille-et-Vilaine": "35", "Indre": "36",
+  "Indre-et-Loire": "37", "Isère": "38", "Jura": "39", "Landes": "40",
+  "Loir-et-Cher": "41", "Loire": "42", "Haute-Loire": "43", "Loire-Atlantique": "44",
+  "Loiret": "45", "Lot": "46", "Lot-et-Garonne": "47", "Lozère": "48",
+  "Maine-et-Loire": "49", "Manche": "50", "Marne": "51", "Haute-Marne": "52",
+  "Mayenne": "53", "Meurthe-et-Moselle": "54", "Meuse": "55", "Morbihan": "56",
+  "Moselle": "57", "Nièvre": "58", "Nord": "59", "Oise": "60", "Orne": "61",
+  "Pas-de-Calais": "62", "Puy-de-Dôme": "63", "Pyrénées-Atlantiques": "64",
+  "Hautes-Pyrénées": "65", "Pyrénées-Orientales": "66", "Bas-Rhin": "67",
+  "Haut-Rhin": "68", "Rhône": "69", "Haute-Saône": "70", "Saône-et-Loire": "71",
+  "Sarthe": "72", "Savoie": "73", "Haute-Savoie": "74", "Paris": "75",
+  "Seine-Maritime": "76", "Seine-et-Marne": "77", "Yvelines": "78",
+  "Deux-Sèvres": "79", "Somme": "80", "Tarn": "81", "Tarn-et-Garonne": "82",
+  "Var": "83", "Vaucluse": "84", "Vendée": "85", "Vienne": "86",
+  "Haute-Vienne": "87", "Vosges": "88", "Yonne": "89", "Territoire de Belfort": "90",
+  "Essonne": "91", "Hauts-de-Seine": "92", "Seine-Saint-Denis": "93",
+  "Val-de-Marne": "94", "Val-d'Oise": "95", "Auvergne-Rhône-Alpes": "84",
+  "Bourgogne-Franche-Comté": "27", "Bretagne": "53", "Centre-Val de Loire": "24",
+  "Corse": "94", "Grand Est": "44", "Hauts-de-France": "32", "Île-de-France": "11",
+  "Normandie": "28", "Nouvelle-Aquitaine": "75", "Occitanie": "76",
+  "Pays de la Loire": "52", "Provence-Alpes-Côte d'Azur": "93",
+  "Guadeloupe": "01", "Martinique": "02", "Guyane": "03", "La Réunion": "04",
+  "Mayotte": "06"
+};
+const HABITATS_DIRECTIVE_CODES = new Set(['CDH1', 'CDH2', 'CDH4', 'CDH5']);
+const OLD_REGIONS_TO_DEPARTMENTS = { 'Alsace': ['67', '68'], 'Aquitaine': ['24', '33', '40', '47', '64'], 'Auvergne': ['03', '15', '43', '63'], 'Basse-Normandie': ['14', '50', '61'], 'Bourgogne': ['21', '58', '71', '89'], 'Champagne-Ardenne': ['08', '10', '51', '52'], 'Franche-Comté': ['25', '39', '70', '90'], 'Haute-Normandie': ['27', '76'], 'Languedoc-Roussillon': ['11', '30', '34', '48', '66'], 'Limousin': ['19', '23', '87'], 'Lorraine': ['54', '55', '57', '88'], 'Midi-Pyrénées': ['09', '12', '31', '32', '46', '65', '81', '82'], 'Nord-Pas-de-Calais': ['59', '62'], 'Picardie': ['02', '60', '80'], 'Poitou-Charentes': ['16', '17', '79', '86'], 'Rhône-Alpes': ['01', '07', '26', '38', '42', '69', '73', '74'] };
+const ADMIN_NAME_TO_CODE_MAP = { "France": "FR", "Ain": "01", "Aisne": "02", "Allier": "03", "Alpes-de-Haute-Provence": "04", "Hautes-Alpes": "05", "Alpes-Maritimes": "06", "Ardèche": "07", "Ardennes": "08", "Ariège": "09", "Aube": "10", "Aude": "11", "Aveyron": "12", "Bouches-du-Rhône": "13", "Calvados": "14", "Cantal": "15", "Charente": "16", "Charente-Maritime": "17", "Cher": "18", "Corrèze": "19", "Corse-du-Sud": "2A", "Haute-Corse": "2B", "Côte-d'Or": "21", "Côtes-d'Armor": "22", "Creuse": "23", "Dordogne": "24", "Doubs": "25", "Drôme": "26", "Eure": "27", "Eure-et-Loir": "28", "Finistère": "29", "Gard": "30", "Haute-Garonne": "31", "Gers": "32", "Gironde": "33", "Hérault": "34", "Ille-et-Vilaine": "35", "Indre": "36", "Indre-et-Loire": "37", "Isère": "38", "Jura": "39", "Landes": "40", "Loir-et-Cher": "41", "Loire": "42", "Haute-Loire": "43", "Loire-Atlantique": "44", "Loiret": "45", "Lot": "46", "Lot-et-Garonne": "47", "Lozère": "48", "Maine-et-Loire": "49", "Manche": "50", "Marne": "51", "Haute-Marne": "52", "Mayenne": "53", "Meurthe-et-Moselle": "54", "Meuse": "55", "Morbihan": "56", "Moselle": "57", "Nièvre": "58", "Nord": "59", "Oise": "60", "Orne": "61", "Pas-de-Calais": "62", "Puy-de-Dôme": "63", "Pyrénées-Atlantiques": "64", "Hautes-Pyrénées": "65", "Pyrénées-Orientales": "66", "Bas-Rhin": "67", "Haut-Rhin": "68", "Rhône": "69", "Haute-Saône": "70", "Saône-et-Loire": "71", "Sarthe": "72", "Savoie": "73", "Haute-Savoie": "74", "Paris": "75", "Seine-Maritime": "76", "Seine-et-Marne": "77", "Yvelines": "78", "Deux-Sèvres": "79", "Somme": "80", "Tarn": "81", "Tarn-et-Garonne": "82", "Var": "83", "Vaucluse": "84", "Vendée": "85", "Vienne": "86", "Haute-Vienne": "87", "Vosges": "88", "Yonne": "89", "Territoire de Belfort": "90", "Essonne": "91", "Hauts-de-Seine": "92", "Seine-Saint-Denis": "93", "Val-de-Marne": "94", "Val-d'Oise": "95", "Auvergne-Rhône-Alpes": "84", "Bourgogne-Franche-Comté": "27", "Bretagne": "53", "Centre-Val de Loire": "24", "Corse": "94", "Grand Est": "44", "Hauts-de-France": "32", "Île-de-France": "11", "Normandie": "28", "Nouvelle-Aquitaine": "75", "Occitanie": "76", "Pays de la Loire": "52", "Provence-Alpes-Côte d'Azur": "93", "Guadeloupe": "01", "Martinique": "02", "Guyane": "03", "La Réunion": "04", "Mayotte": "06" };
 let bdcRulesByTaxon = new Map();
 let bdcDataPromise = null;
 
@@ -1214,16 +1262,86 @@ async function runStatusAnalysis() {
   const btn = document.getElementById('status-analysis-btn');
   if (btn) { btn.disabled = true; btn.textContent = 'Analyse...'; }
   await loadBDCData();
-  let depName = '', regName = '';
+
+  let coords;
   try {
-    const resp = await fetch(`https://geo.api.gouv.fr/communes?lat=${userLocation.latitude}&lon=${userLocation.longitude}&fields=departement,region`);
-    const loc = (await resp.json())[0];
-    depName = loc.departement.nom.toLowerCase();
-    regName = loc.region.nom.toLowerCase();
-  } catch(e) { console.error(e); }
+    coords = await new Promise((resolve, reject) => {
+      if (!navigator.geolocation) return reject(new Error('Géolocalisation non supportée'));
+      navigator.geolocation.getCurrentPosition(p => resolve({ latitude: p.coords.latitude, longitude: p.coords.longitude }), reject, { timeout: 10000 });
+    });
+    userLocation = coords;
+  } catch (e) {
+    showNotification('Erreur de géolocalisation', 'error');
+    if (btn) { btn.disabled = false; btn.textContent = 'Analyse statuts'; }
+    return;
+  }
 
   const table = document.querySelector('#results table');
   if (!table) { if(btn){btn.disabled=false;btn.textContent='Analyse statuts';} return; }
+
+  const speciesNames = [];
+  table.querySelectorAll('tbody tr').forEach(tr => {
+    const latinCell = tr.querySelector('.col-nom-latin');
+    const name = latinCell ? (latinCell.dataset.latin || latinCell.textContent.split('\n')[0]).trim() : '';
+    if (name) speciesNames.push(name);
+  });
+
+  let departement, region;
+  try {
+    const resp = await fetch(`https://geo.api.gouv.fr/communes?lat=${coords.latitude}&lon=${coords.longitude}&fields=departement,region`);
+    const loc = (await resp.json())[0];
+    departement = loc.departement;
+    region = loc.region;
+  } catch (e) { console.error(e); }
+
+  const relevantRules = new Map();
+  for (const name of speciesNames) {
+    const rulesForThisTaxon = bdcRulesByTaxon.get(name) || [];
+    for (const row of rulesForThisTaxon) {
+      let ruleApplies = false;
+      const type = row.type.toLowerCase();
+      const isHabDirective = type.includes('directive habitat') && HABITATS_DIRECTIVE_CODES.has(row.code);
+      if (isHabDirective) {
+        ruleApplies = true;
+      } else if (ADMIN_NAME_TO_CODE_MAP[row.adm] === 'FR' || type.includes('nationale')) {
+        ruleApplies = true;
+      } else if (OLD_REGIONS_TO_DEPARTMENTS[row.adm]?.includes(departement?.code)) {
+        ruleApplies = true;
+      } else {
+        const adminCode = ADMIN_NAME_TO_CODE_MAP[row.adm];
+        if (adminCode === departement?.code || adminCode === region?.code) ruleApplies = true;
+      }
+      if (ruleApplies) {
+        if (nonPatrimonialLabels.has(row.label) || type.includes('déterminante znieff')) continue;
+        const isRedList = type.includes('liste rouge');
+        if (isRedList && nonPatrimonialRedlistCodes.has(row.code)) continue;
+        const key = `${row.nom}|${row.type}|${row.adm}`;
+        if (!relevantRules.has(key)) {
+          const desc = isRedList ? `${row.type} (${row.code}) (${row.adm})` : row.label;
+          relevantRules.set(key, { species: row.nom, status: desc });
+        }
+      }
+    }
+  }
+
+  let patrimonialMap = {};
+  try {
+    const resp = await fetch('/.netlify/functions/analyze-patrimonial-status', {
+      method: 'POST',
+      body: JSON.stringify({
+        relevantRules: Array.from(relevantRules.values()),
+        uniqueSpeciesNames: speciesNames,
+        coords
+      })
+    });
+    if (!resp.ok) throw new Error(await resp.text());
+    patrimonialMap = await resp.json();
+  } catch (e) {
+    showNotification('Erreur durant l\'analyse', 'error');
+    if (btn) { btn.disabled = false; btn.textContent = 'Analyse statuts'; }
+    return;
+  }
+
   const headerRow = table.querySelector('thead tr');
   if (headerRow && !headerRow.querySelector('.statut-header')) {
     const th = document.createElement('th');
@@ -1231,25 +1349,14 @@ async function runStatusAnalysis() {
     th.className = 'statut-header';
     headerRow.appendChild(th);
   }
+
   table.querySelectorAll('tbody tr').forEach(tr => {
     const latinCell = tr.querySelector('.col-nom-latin');
     const name = latinCell ? (latinCell.dataset.latin || latinCell.textContent.split('\n')[0]).trim() : '';
-    const rules = bdcRulesByTaxon.get(name) || [];
-    const statuses = [];
-    rules.forEach(r => {
-      const type = r.type.toLowerCase();
-      if (nonPatrimonialLabels.has(r.label) || type.includes('déterminante znieff')) return;
-      if (type.includes('liste rouge') && nonPatrimonialRedlistCodes.has(r.code)) return;
-      const admin = (r.adm || '').toLowerCase();
-      const applies = r.level.toLowerCase().includes('état') || admin === 'france' || admin === depName || admin === regName;
-      if (applies) {
-        const st = type.includes('liste rouge') ? `${r.type} (${r.code})` : r.label;
-        if (!statuses.includes(st)) statuses.push(st);
-      }
-    });
+    const statuses = patrimonialMap[name] || [];
     const td = document.createElement('td');
     td.className = 'col-statut';
-    if (statuses.length) {
+    if (Array.isArray(statuses) && statuses.length) {
       td.innerHTML = '<ul>' + statuses.map(s => `<li>${s}</li>`).join('') + '</ul>';
     } else {
       td.textContent = '—';


### PR DESCRIPTION
## Summary
- ask for user's geolocation before analysing statuses in identification results
- reuse the same patrimonial status logic as the biblio-patri page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9668936c832cb7b914f1caf4685d