### PR TITLE
Fix mobile layout for biblio tab

### DIFF
--- a/style.css
+++ b/style.css
@@ -207,7 +207,7 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
         width: 100%;
     }
     .button-grid {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(2, 1fr);
     }
 }
 /* Style pour la navigation principale (issue de l'app cible) */


### PR DESCRIPTION
## Summary
- keep buttons side by side on mobile screens in the "Biblio Patri" tab

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605ede9530832cbc0e6d354d3c001b