### PR TITLE
Fix status column wrapping in summary table

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,11 @@
       .col-phenologie { width: 22%; font-size: 0.9em; }
       .col-link { width: 6%; text-align: center; }
       /* Colonne des statuts : affichage sur une seule ligne */
-      .col-statut { white-space: nowrap; }
+      .col-statut {
+         white-space: nowrap;
+         overflow-wrap: normal;
+         word-break: normal;
+      }
       .col-statut .status-item { margin-right: 0.6em; }
       .logo-icon { width: 24px; height: auto; }
       .small-logo { height: 24px; width: auto; }


### PR DESCRIPTION
## Summary
- ensure the `Statut` column doesn't wrap when many statuses are displayed

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860606bfa84832c85f511a06e3cd703