### PR TITLE
Improve mobile search layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -195,16 +195,20 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
     .search-controls {
         flex-direction: column;
         align-items: stretch;
+        gap: 0.5rem;
     }
     .search-group {
         flex-basis: 100%;
     }
     .search-group.address-group {
-        flex-direction: column;
+        flex-direction: row;
     }
-    .search-group.address-group input,
+    .search-group.address-group input {
+        flex: 1;
+    }
     .search-group.address-group button {
-        width: 100%;
+        width: auto;
+        flex: 0 0 auto;
     }
     .button-grid {
         grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
## Summary
- keep address search button in the same row as the input on mobile screens
- reduce vertical spacing in mobile search controls

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860d6699634832c910aad091eb1f31d