### PR TITLE
Improve biblio Patri mobile layout

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -45,8 +45,6 @@
                     <button id="use-geolocation-btn" class="action-button">📍 Ma position</button>
                     <button id="select-on-map-btn" class="action-button">🗺️ Choisir sur la carte</button>
                     <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
-                </div>
-                <div class="button-grid">
                     <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
                     <button id="toggle-labels-btn" class="action-button">Masquer les étiquettes</button>
                 </div>
@@ -68,8 +66,6 @@
                 <div class="button-grid">
                     <button id="obs-geoloc-btn" class="action-button">📍 Ma position</button>
                     <button id="obs-draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
-                </div>
-                <div class="button-grid">
                     <button id="obs-toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
                     <button id="obs-toggle-labels-btn" class="action-button">Masquer les étiquettes</button>
                 </div>

--- a/style.css
+++ b/style.css
@@ -90,7 +90,7 @@ h1 {
 
 .button-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
     gap: 0.5rem;
     width: 100%;
 }
@@ -189,8 +189,8 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
         border-radius: 0;
     }
     .action-button {
-        padding: 0.8rem;
-        font-size: 1rem;
+        padding: 0.6rem;
+        font-size: 0.9rem;
     }
     .search-controls {
         flex-direction: column;
@@ -211,7 +211,7 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
         flex: 0 0 auto;
     }
     .button-grid {
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(3, 1fr);
     }
 }
 /* Style pour la navigation principale (issue de l'app cible) */


### PR DESCRIPTION
## Summary
- merge control buttons into single grid on biblio-patri page
- adjust button-grid columns for better mobile display
- shrink action buttons on small screens

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686139e7d088832c83cb46f9e664b153