### PR TITLE
Ajout de sous-onglets pour le contexte environnemental

### DIFF
--- a/contexte.html
+++ b/contexte.html
@@ -177,19 +177,27 @@
       </div>
       
       <div class="loading" id="loading"></div>
-      
-      <div class="results-section" id="results-section">
-         <h2 style="margin-top:2rem;">Carte interactive</h2>
-         <div id="layer-controls" style="margin-bottom:0.5rem;"></div>
-         <button id="measure-distance" class="small-button" style="display:none;margin-bottom:0.5rem;">Mesurer une distance</button>
-         <div id="env-map" class="map-fullwidth" style="height:80vh;display:none;"></div>
 
-         <h2>Ressources environnementales</h2>
-         <p style="margin-bottom: 1rem; color: #666;">
-            Cliquez sur les liens ci-dessous pour explorer le contexte environnemental de la zone sélectionnée :
-         </p>
-         <div class="results-grid" id="results-grid">
-            </div>
+      <div class="results-section" id="results-section">
+         <div class="tabs">
+            <button id="zonage-tab-btn" class="tab-button active">Zonage</button>
+            <button id="resources-tab-btn" class="tab-button">Ressources</button>
+         </div>
+
+         <div id="zonage-tab" class="tab-content" style="display:block;">
+            <h2 style="margin-top:2rem;">Carte interactive</h2>
+            <div id="layer-controls" style="margin-bottom:0.5rem;"></div>
+            <button id="measure-distance" class="small-button" style="display:none;margin-bottom:0.5rem;">Mesurer une distance</button>
+            <div id="env-map" class="map-fullwidth" style="height:80vh;display:none;"></div>
+         </div>
+
+         <div id="resources-tab" class="tab-content" style="display:none;">
+            <h2>Ressources environnementales</h2>
+            <p style="margin-bottom: 1rem; color: #666;">
+               Cliquez sur les liens ci-dessous pour explorer le contexte environnemental de la zone sélectionnée :
+            </p>
+            <div class="results-grid" id="results-grid"></div>
+         </div>
       </div>
    </div>
 </body>

--- a/contexte.js
+++ b/contexte.js
@@ -148,6 +148,13 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('open-gmaps').addEventListener('click', openInGmaps);
         document.getElementById('reset-selection').addEventListener('click', resetSelection);
         document.getElementById('measure-distance').addEventListener('click', toggleMeasure);
+        const zonageTabBtn = document.getElementById('zonage-tab-btn');
+        const resourcesTabBtn = document.getElementById('resources-tab-btn');
+        if (zonageTabBtn && resourcesTabBtn) {
+                zonageTabBtn.addEventListener('click', () => switchSubTab('zonage'));
+                resourcesTabBtn.addEventListener('click', () => switchSubTab('resources'));
+                switchSubTab('zonage');
+        }
         initializeMap();
         toggleMap();
 });
@@ -634,6 +641,26 @@ function resetSelection() {
     document.getElementById('choose-on-map').textContent = '🗺️ Ouvrir la carte';
     document.getElementById('measure-distance').style.display = 'none';
     if (measuring && envMap) toggleMeasure();
+}
+
+// Affiche l'onglet demandé dans la section des résultats
+function switchSubTab(tab) {
+    const zonageTab = document.getElementById('zonage-tab');
+    const resourcesTab = document.getElementById('resources-tab');
+    const zonageBtn = document.getElementById('zonage-tab-btn');
+    const resourcesBtn = document.getElementById('resources-tab-btn');
+    if (!zonageTab || !resourcesTab || !zonageBtn || !resourcesBtn) return;
+    if (tab === 'zonage') {
+        zonageTab.style.display = 'block';
+        resourcesTab.style.display = 'none';
+        zonageBtn.classList.add('active');
+        resourcesBtn.classList.remove('active');
+    } else {
+        zonageTab.style.display = 'none';
+        resourcesTab.style.display = 'block';
+        zonageBtn.classList.remove('active');
+        resourcesBtn.classList.add('active');
+    }
 }
 
 // Gestionnaire pour le retour à la page d'accueil


### PR DESCRIPTION
## Résumé
- ajoute deux sous-onglets "Zonage" et "Ressources" dans la page contexte
- permet de basculer entre les sous-onglets via `switchSubTab`

## Test
- `npm test` *(échoue : jest absent)*

------
https://chatgpt.com/codex/tasks/task_e_68613fdce814832c81afe174f2985164