### PR TITLE
Add altitude fetch using Open-Meteo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Plantouille Express est une application web progressive qui aide à l'identifica
 - synthèse audio avec l'API Google Text‑to‑Speech
 - consultation hors ligne grâce au service worker
 - cartes patrimoniales et couches contextuelles (INPN, Biodiv'AURA, IGN)
+- récupération de l'altitude via l'API Open‑Meteo
 
 ## Prérequis
 

--- a/contexte.js
+++ b/contexte.js
@@ -147,7 +147,23 @@ function latLonToWebMercator(lat, lon) {
         return { x, y };
 }
 
+async function fetchAltitudeFromApi(lat, lon) {
+    try {
+        const resp = await fetch(
+            `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m`
+        );
+        if (!resp.ok) throw new Error('api');
+        const json = await resp.json();
+        if (typeof json.elevation === 'number') return json.elevation;
+    } catch (e) {
+        return null;
+    }
+    return null;
+}
+
 async function fetchAltitude(lat, lon) {
+    const apiAlt = await fetchAltitudeFromApi(lat, lon);
+    if (apiAlt !== null) return apiAlt;
     const data = await loadAltitudeData();
     const round = v => (Math.round(v * 2) / 2).toFixed(1);
     const key = `${round(lat)},${round(lon)}`;


### PR DESCRIPTION
## Summary
- fetch altitude from Open-Meteo API with offline fallback
- document altitude retrieval in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b8b2b9c8832cb8dbc06c355878cf