### PR TITLE
Adjust map label opacity

### DIFF
--- a/style.css
+++ b/style.css
@@ -174,6 +174,7 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
     border-radius: 50%;
     margin-right: 8px;
     vertical-align: middle;
+    opacity: 0.5;
 }
 
 @media (min-width: 600px) {
@@ -228,4 +229,12 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
     background: rgba(255, 255, 255, 0.8) !important;
     border-color: rgba(255, 255, 255, 0.8) !important;
     color: var(--text);
+}
+
+/* Icônes de clusters semi-transparents pour plus de lisibilité de la carte */
+.custom-cluster .marker-cluster-icon {
+    opacity: 0.5;
+}
+.custom-cluster .marker-cluster-icon span {
+    opacity: 1;
 }


### PR DESCRIPTION
## Summary
- reduce intensity of map legend color dots
- make cluster icons semi-transparent for better visibility

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686386b8f128832cab52458764359922