### PR TITLE
Unify analysis selection via map popup

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -34,49 +34,28 @@
         </div>
     </nav>
     <div class="main-content">
-        <div class="tabs">
-            <button id="analysis-tab-btn" class="tab-button active">Analyse patrimoniale</button>
-            <button id="observations-tab-btn" class="tab-button">Observations locales</button>
-        </div>
-        
-        <div id="analysis-tab" class="tab-content" style="display:block;">
-            <div class="search-controls">
-                <div class="search-group address-group">
-                    <input type="text" id="address-input" placeholder="Saisir une adresse, une ville, un lieu...">
-                    <button id="search-address-btn" class="action-button">🔍 Rechercher</button>
-                </div>
-                <div class="button-grid">
-                    <button id="use-geolocation-btn" class="action-button">📍 Ma position</button>
-                    <button id="select-on-map-btn" class="action-button">🗺️ Choisir sur la carte</button>
-                    <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
-                    <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
-                    <button id="toggle-labels-btn" class="action-button">Masquer les étiquettes</button>
-                </div>
+        <div class="search-controls">
+            <div class="search-group address-group">
+                <input type="text" id="address-input" placeholder="Saisir une adresse, une ville, un lieu...">
+                <button id="search-address-btn" class="action-button">🔍 Rechercher</button>
             </div>
-
-            <div id="status" class="status-container"></div>
-
-            <div id="map"></div>
-
-            <div id="download-container" style="text-align:center; display:none; margin-bottom:1rem;">
-                <button id="download-shapefile-btn" class="action-button">⬇️ Shapefile</button>
+            <div class="button-grid">
+                <button id="use-geolocation-btn" class="action-button">📍 Ma position</button>
+                <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
+                <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
+                <button id="toggle-labels-btn" class="action-button">Masquer les étiquettes</button>
             </div>
-
-            <div id="results" class="results-container"></div>
         </div>
 
-        <div id="observations-tab" class="tab-content" style="display:none;">
-            <div class="search-controls">
-                <div class="button-grid">
-                    <button id="obs-geoloc-btn" class="action-button">📍 Ma position</button>
-                    <button id="obs-draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
-                    <button id="obs-toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
-                    <button id="obs-toggle-labels-btn" class="action-button">Masquer les étiquettes</button>
-                </div>
-            </div>
-            <div id="obs-status" class="status-container"></div>
-            <div id="observations-map"></div>
+        <div id="status" class="status-container"></div>
+
+        <div id="map"></div>
+
+        <div id="download-container" style="text-align:center; display:none; margin-bottom:1rem;">
+            <button id="download-shapefile-btn" class="action-button">⬇️ Shapefile</button>
         </div>
+
+        <div id="results" class="results-container"></div>
     </div>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -121,7 +121,7 @@ h1 {
     min-height: 24px;
 }
 
-#map, #observations-map {
+#map {
     height: 60vh;
     width: 100%;
     border-radius: 8px;
@@ -130,8 +130,7 @@ h1 {
     margin: 1.5rem 0;
 }
 
-#map.hide-labels .leaflet-tooltip,
-#observations-map.hide-labels .leaflet-tooltip {
+#map.hide-labels .leaflet-tooltip {
     display: none;
 }
 
@@ -182,8 +181,7 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
 }
 
 @media (max-width: 599px) {
-    #map,
-    #observations-map {
+    #map {
         margin-left: -1rem;
         margin-right: -1rem;
         width: calc(100% + 2rem);


### PR DESCRIPTION
## Summary
- remove tabs from *Biblio Patri* page and use a single map
- add popup to choose between patrimonial and local observations analyses
- simplify address/geolocation handlers to center map and show popup
- merge observations view into main map and clean CSS

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865239be4a8832cb8e3f027368dde41