### PR TITLE
Adjust library map height

### DIFF
--- a/style.css
+++ b/style.css
@@ -122,12 +122,12 @@ h1 {
 }
 
 #map {
-    height: 60vh;
+    height: 75vh;
     width: 100%;
     border-radius: 8px;
     border: 1px solid var(--border);
     box-shadow: 0 2px 6px rgba(0,0,0,.1);
-    margin: 1.5rem 0;
+    margin: 0 0 1.5rem;
 }
 
 #map.hide-labels .leaflet-tooltip {


### PR DESCRIPTION
## Summary
- increase `#map` height and reduce top margin so the library page map fills more of the screen

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a80a3cc4832c9abcc21790afaeee