### PR TITLE
Align library page buttons horizontally on mobile

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -39,7 +39,7 @@
                 <input type="text" id="address-input" placeholder="Saisir une adresse, une ville, un lieu...">
                 <button id="search-address-btn" class="action-button">🔍 Rechercher</button>
             </div>
-            <div class="button-grid">
+            <div class="button-grid button-scroll">
                 <button id="use-geolocation-btn" class="action-button">📍 Ma position</button>
                 <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
                 <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>

--- a/style.css
+++ b/style.css
@@ -95,6 +95,18 @@ h1 {
     width: 100%;
 }
 
+/* Horizontal scrolling layout for action buttons */
+.button-scroll {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    gap: 0.5rem;
+    width: 100%;
+}
+.button-scroll > .action-button {
+    flex: 1 0 auto;
+}
+
 #address-input {
     flex: 1;
     padding: 0.6rem;


### PR DESCRIPTION
## Summary
- add `.button-scroll` class for horizontal button layout
- apply horizontal scrolling layout to library page button bar

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a8b54280832ca5ce7f9bacf7a9d3