### PR TITLE
Improve layout for biblio-patri page

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -39,7 +39,7 @@
                 <input type="text" id="address-input" placeholder="Saisir une adresse, une ville, un lieu...">
                 <button id="search-address-btn" class="action-button">🔍 Rechercher</button>
             </div>
-            <div class="button-grid button-scroll">
+            <div class="button-grid">
                 <button id="use-geolocation-btn" class="action-button">📍 Ma position</button>
                 <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
                 <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>

--- a/style.css
+++ b/style.css
@@ -78,7 +78,7 @@ h1 {
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem;
-    margin-bottom: 1rem;
+    margin-bottom: 0.5rem;
     align-items: center;
 }
 .search-group {
@@ -90,22 +90,12 @@ h1 {
 
 .button-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 0.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+    gap: 0.25rem;
     width: 100%;
 }
 
-/* Horizontal scrolling layout for action buttons */
-.button-scroll {
-    display: flex;
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    gap: 0.5rem;
-    width: 100%;
-}
-.button-scroll > .action-button {
-    flex: 1 0 auto;
-}
+
 
 #address-input {
     flex: 1;
@@ -128,7 +118,7 @@ h1 {
 
 .status-container {
     text-align: center;
-    margin: 1rem 0;
+    margin: 0.5rem 0;
     font-size: 1rem;
     min-height: 24px;
 }
@@ -139,7 +129,7 @@ h1 {
     border-radius: 8px;
     border: 1px solid var(--border);
     box-shadow: 0 2px 6px rgba(0,0,0,.1);
-    margin: 0 0 1.5rem;
+    margin: 0 0 1rem;
 }
 
 #map.hide-labels .leaflet-tooltip {


### PR DESCRIPTION
## Summary
- keep search bar on first line and group action buttons below
- tighten spacing around map and status messages
- drop horizontal scrolling for buttons so everything fits the viewport

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865aa65d440832cb9765d9979f2fa6f