### PR TITLE
Add context eco layers toggle

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -44,6 +44,7 @@
                 <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
                 <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
                 <button id="toggle-labels-btn" class="action-button">Masquer les étiquettes</button>
+                <button id="load-context-btn" class="action-button">🌿 Contexte éco</button>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add a "Contexte éco" button to the biblio map page
- support APICarto environmental layers in `biblio-patri.js`
- fetch layers on demand and add them to the map

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ab8b44c0832cad6e2709174c8756