### PR TITLE
Add context eco layers button

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -44,6 +44,7 @@
                 <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
                 <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
                 <button id="toggle-labels-btn" class="action-button">Masquer les étiquettes</button>
+                <button id="load-eco-btn" class="action-button">Contexte éco</button>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add a *Contexte éco* button in the Biblio Patri page
- load IGN environmental layers on demand
- wire button to fetch and display the layers on the main map

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ab8f8cb8832c9017275264077fac