### PR TITLE
Improve spacing of map popup buttons

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -86,7 +86,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const showChoicePopup = (latlng, extra = {}) => {
         if (!map) return;
-        const container = L.DomUtil.create('div');
+        const container = L.DomUtil.create('div', 'popup-button-container');
         const patrBtn = L.DomUtil.create('button', 'action-button', container);
         patrBtn.textContent = 'Flore patrimoniale';
         const obsBtn = L.DomUtil.create('button', 'action-button', container);

--- a/style.css
+++ b/style.css
@@ -247,3 +247,9 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
     opacity: 1;
     line-height: 1;
 }
+
+/* Espace dans la fenêtre de choix des analyses */
+.popup-button-container {
+    display: flex;
+    gap: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- tweak map popup styling to add a small gap between the action buttons

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865aca39328832ca428170de4a93aac