### PR TITLE
Improve JSON body validation

### DIFF
--- a/netlify/functions/analyze-patrimonial-status.js
+++ b/netlify/functions/analyze-patrimonial-status.js
@@ -7,9 +7,15 @@ const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 exports.handler = async function(event) {
     if (event.httpMethod !== 'POST') return { statusCode: 405, body: 'Method Not Allowed' };
 
+    let relevantRules, uniqueSpeciesNames, coords;
     try {
-        // Le corps de la requête contient maintenant les règles déjà filtrées.
-        const { relevantRules, uniqueSpeciesNames, coords } = JSON.parse(event.body);
+        ({ relevantRules, uniqueSpeciesNames, coords } = JSON.parse(event.body));
+    } catch (parseErr) {
+        console.error('Invalid JSON body for analyze-patrimonial-status:', parseErr);
+        return { statusCode: 400, body: 'Requête JSON invalide' };
+    }
+
+    try {
         if (!relevantRules || !uniqueSpeciesNames || !coords) return { statusCode: 400, body: 'Données d\'entrée invalides.' };
 
         const { departement, region } = (await (await fetch(`https://geo.api.gouv.fr/communes?lat=${coords.latitude}&lon=${coords.longitude}&fields=departement,region`)).json())[0];

--- a/netlify/functions/api-proxy.js
+++ b/netlify/functions/api-proxy.js
@@ -13,8 +13,15 @@ exports.handler = async (event) => {
         return { statusCode: 405, body: 'Method Not Allowed' };
     }
 
+    let target, payload;
     try {
-        const { target, payload } = JSON.parse(event.body);
+        ({ target, payload } = JSON.parse(event.body));
+    } catch (parseErr) {
+        console.error('Invalid JSON body for api-proxy:', parseErr);
+        return { statusCode: 400, body: 'Requête JSON invalide' };
+    }
+
+    try {
         let upstreamUrl = '';
         let upstreamOptions = {};
 


### PR DESCRIPTION
## Summary
- validate request JSON more carefully in serverless functions
- return 400 for malformed JSON bodies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f4bd67c4832ca0efeb87df29543c