### PR TITLE
Fix GBIF map search

### DIFF
--- a/__tests__/gbif-proxy.test.js
+++ b/__tests__/gbif-proxy.test.js
@@ -1,0 +1,27 @@
+const { loadGbifHandler } = require('../test-utils');
+
+function createMockFetch(body) {
+  return jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(body)
+  });
+}
+
+describe('gbif-proxy handler', () => {
+  test('calls correct endpoint', async () => {
+    const fetchMock = createMockFetch('{"ok":true}');
+    const handler = loadGbifHandler(fetchMock);
+    const res = await handler({ queryStringParameters: { endpoint: 'match', name: 'Acer' } });
+    expect(fetchMock).toHaveBeenCalledWith('https://api.gbif.org/v1/species/match?name=Acer');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('{"ok":true}');
+  });
+
+  test('returns 400 for invalid endpoint', async () => {
+    const fetchMock = createMockFetch('{}');
+    const handler = loadGbifHandler(fetchMock);
+    const res = await handler({ queryStringParameters: { endpoint: 'foo' } });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/carte_interactive/script.js
+++ b/carte_interactive/script.js
@@ -98,7 +98,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const searchSingleSpecies = async (speciesName, wktPolygon, color) => {
             try {
-                const matchUrl = `https://api.gbif.org/v1/species/match?name=${encodeURIComponent(speciesName)}`;
+                const matchUrl = `/api/gbif?endpoint=match&name=${encodeURIComponent(speciesName)}`;
                 const matchResponse = await fetch(matchUrl);
                 if (!matchResponse.ok) throw new Error(`Erreur de validation du nom d'espèce (HTTP ${matchResponse.status})`);
                 const matchData = await matchResponse.json();
@@ -111,7 +111,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const pageSize = 300; 
 
                 while (keepFetching && allResults.length < maxOccurrences) {
-                    const occurrenceUrl = `https://api.gbif.org/v1/occurrence/search?taxonKey=${matchData.usageKey}&geometry=${encodeURIComponent(wktPolygon)}&limit=${pageSize}&offset=${offset}`;
+                    const occurrenceUrl = `/api/gbif?endpoint=search&taxonKey=${matchData.usageKey}&geometry=${encodeURIComponent(wktPolygon)}&limit=${pageSize}&offset=${offset}`;
                     const occResponse = await fetch(occurrenceUrl);
                     
                     if (!occResponse.ok) {

--- a/netlify.toml
+++ b/netlify.toml
@@ -32,3 +32,9 @@
   status = 200
   # Force l'application de cette règle
   force = true
+
+[[redirects]]
+  from = "/api/gbif"
+  to = "/.netlify/functions/gbif-proxy"
+  status = 200
+  force = true

--- a/netlify/functions/gbif-proxy.js
+++ b/netlify/functions/gbif-proxy.js
@@ -1,0 +1,32 @@
+const fetch = (...args) => import('node-fetch').then(({default: f}) => f(...args));
+
+const ENDPOINTS = {
+  match: 'https://api.gbif.org/v1/species/match',
+  search: 'https://api.gbif.org/v1/occurrence/search'
+};
+
+exports.handler = async function(event) {
+  const params = event.queryStringParameters || {};
+  const endpoint = params.endpoint;
+  if (!endpoint || !ENDPOINTS[endpoint]) {
+    return { statusCode: 400, body: 'Invalid or missing endpoint' };
+  }
+
+  const url = new URL(ENDPOINTS[endpoint]);
+  for (const [key, value] of Object.entries(params)) {
+    if (key !== 'endpoint') url.searchParams.append(key, value);
+  }
+
+  try {
+    const resp = await fetch(url.toString());
+    const body = await resp.text();
+    return {
+      statusCode: resp.status,
+      headers: { 'Content-Type': 'application/json' },
+      body
+    };
+  } catch (err) {
+    console.error('GBIF proxy error:', err);
+    return { statusCode: 500, body: 'Server error' };
+  }
+};

--- a/test-utils.js
+++ b/test-utils.js
@@ -58,6 +58,19 @@ function loadAuraHandler(mockFetch) {
   return context.exports.handler;
 }
 
+function loadGbifHandler(mockFetch) {
+  const code = fs.readFileSync('netlify/functions/gbif-proxy.js', 'utf-8');
+  const patched = code.replace(
+    /const fetch = \(\.\.\.args\) => import\("node-fetch"\)\.then\(\(\{default: f\}\) => f\(\.\.\.args\)\);/,
+    'const fetch = (...args) => global.__fetch(...args);'
+  );
+  const context = { require, console, exports: {}, __fetch: mockFetch };
+  context.global = context;
+  vm.createContext(context);
+  vm.runInContext(patched, context);
+  return context.exports.handler;
+}
+
 function mockFetch(html) {
   return jest.fn().mockResolvedValue({
     ok: true,
@@ -65,4 +78,4 @@ function mockFetch(html) {
   });
 }
 
-module.exports = { loadApp, loadHandler, loadAuraHandler, mockFetch };
+module.exports = { loadApp, loadHandler, loadAuraHandler, loadGbifHandler, mockFetch };


### PR DESCRIPTION
## Summary
- proxy GBIF API calls through a new Netlify function
- use the proxy in the interactive map
- add redirect rule for the new function
- extend test utilities and add unit tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699ee4999c832c8a122084ab090190