### PR TITLE
Fix species map via GBIF proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm init -y
 npm install jsdom node-fetch
 ```
 
-Les fonctions `inpn-proxy.js` et `aura-images.js` utilisent ces modules.
+Les fonctions `inpn-proxy.js`, `aura-images.js` et `gbif-proxy.js` utilisent ces modules.
 
 ## Configuration
 
@@ -70,4 +70,5 @@ Poussez le dépôt sur GitHub puis créez un site sur Netlify. Le fichier `netli
 - carte contextuelle avec couches IGN (réserves, zones humides, etc.)
 - recherche par trigramme et suggestions via TaxRef Match
 - comparaison d'espèces et synthèse vocale optionnelle
+- carte interactive de localisation via l'API GBIF (proxy Netlify)
 

--- a/__tests__/gbif-proxy.test.js
+++ b/__tests__/gbif-proxy.test.js
@@ -1,0 +1,21 @@
+const { loadGbifHandler } = require('../test-utils');
+
+describe('gbif-proxy handler', () => {
+  test('forwards request to GBIF', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/json' },
+      text: () => Promise.resolve('{"ok":true}')
+    });
+    const handler = loadGbifHandler(fetchMock);
+    const res = await handler({
+      path: '/.netlify/functions/gbif-proxy/v1/species/match',
+      rawQuery: 'name=Abies%20alba',
+      queryStringParameters: { name: 'Abies alba' }
+    });
+    expect(fetchMock).toHaveBeenCalledWith('https://api.gbif.org/v1/species/match?name=Abies%20alba');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('{"ok":true}');
+  });
+});

--- a/carte_interactive/script.js
+++ b/carte_interactive/script.js
@@ -98,7 +98,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const searchSingleSpecies = async (speciesName, wktPolygon, color) => {
             try {
-                const matchUrl = `https://api.gbif.org/v1/species/match?name=${encodeURIComponent(speciesName)}`;
+                const matchUrl = `/api/gbif/v1/species/match?name=${encodeURIComponent(speciesName)}`;
                 const matchResponse = await fetch(matchUrl);
                 if (!matchResponse.ok) throw new Error(`Erreur de validation du nom d'espèce (HTTP ${matchResponse.status})`);
                 const matchData = await matchResponse.json();
@@ -111,7 +111,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const pageSize = 300; 
 
                 while (keepFetching && allResults.length < maxOccurrences) {
-                    const occurrenceUrl = `https://api.gbif.org/v1/occurrence/search?taxonKey=${matchData.usageKey}&geometry=${encodeURIComponent(wktPolygon)}&limit=${pageSize}&offset=${offset}`;
+                    const occurrenceUrl = `/api/gbif/v1/occurrence/search?taxonKey=${matchData.usageKey}&geometry=${encodeURIComponent(wktPolygon)}&limit=${pageSize}&offset=${offset}`;
                     const occResponse = await fetch(occurrenceUrl);
                     
                     if (!occResponse.ok) {

--- a/netlify.toml
+++ b/netlify.toml
@@ -32,3 +32,9 @@
   status = 200
   # Force l'application de cette règle
   force = true
+
+[[redirects]]
+  from = "/api/gbif/*"
+  to = "/.netlify/functions/gbif-proxy/:splat"
+  status = 200
+  force = true

--- a/netlify/functions/gbif-proxy.js
+++ b/netlify/functions/gbif-proxy.js
@@ -1,0 +1,19 @@
+const fetch = (...args) => import('node-fetch').then(({default: f}) => f(...args));
+
+exports.handler = async function(event) {
+    try {
+        const path = event.path.replace('/.netlify/functions/gbif-proxy', '');
+        const query = event.rawQuery ? `?${event.rawQuery}` : '';
+        const url = `https://api.gbif.org${path}${query}`;
+        const resp = await fetch(url);
+        const body = await resp.text();
+        return {
+            statusCode: resp.status,
+            headers: { 'Content-Type': resp.headers.get('content-type') || 'application/json' },
+            body
+        };
+    } catch (err) {
+        console.error('gbif-proxy error:', err);
+        return { statusCode: 500, body: JSON.stringify({ error: 'Proxy fetch error' }) };
+    }
+};

--- a/test-utils.js
+++ b/test-utils.js
@@ -58,6 +58,19 @@ function loadAuraHandler(mockFetch) {
   return context.exports.handler;
 }
 
+function loadGbifHandler(mockFetch) {
+  const code = fs.readFileSync('netlify/functions/gbif-proxy.js', 'utf-8');
+  const patched = code.replace(
+    /const fetch = \(\.\.\.args\) => import\(['"]node-fetch['"]\)\.then\(\(\{default: f\}\) => f\(\.\.\.args\)\);/,
+    'const fetch = (...args) => global.__fetch(...args);'
+  );
+  const context = { require, console, exports: {}, __fetch: mockFetch };
+  context.global = context;
+  vm.createContext(context);
+  vm.runInContext(patched, context);
+  return context.exports.handler;
+}
+
 function mockFetch(html) {
   return jest.fn().mockResolvedValue({
     ok: true,
@@ -65,4 +78,4 @@ function mockFetch(html) {
   });
 }
 
-module.exports = { loadApp, loadHandler, loadAuraHandler, mockFetch };
+module.exports = { loadApp, loadHandler, loadAuraHandler, loadGbifHandler, mockFetch };


### PR DESCRIPTION
## Summary
- add Netlify function `gbif-proxy.js` to proxy GBIF API requests
- route `/api/gbif/*` URLs to the new function
- switch the interactive map to use the proxy
- document the proxy in README
- update tests and utilities for the new function

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699ee4999c832c8a122084ab090190