### PR TITLE
Limit observation search radius

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -744,13 +744,17 @@ const initializeSelectionMap = (coords) => {
         }
     };
 
-    const loadObservationsAt = async (params) => {
-        try {
-            if (!map) initializeSelectionMap(params);
-            mapContainer.style.display = 'block';
-            if (obsSearchCircle) { map.removeLayer(obsSearchCircle); obsSearchCircle = null; }
-            if (obsSearchPolygon) { map.removeLayer(obsSearchPolygon); obsSearchPolygon = null; }
-            let wkt;
+      const loadObservationsAt = async (params) => {
+          try {
+              if (!map) initializeSelectionMap(params);
+              mapContainer.style.display = 'block';
+              if (searchAreaLayer) {
+                  map.removeLayer(searchAreaLayer);
+                  searchAreaLayer = null;
+              }
+              if (obsSearchCircle) { map.removeLayer(obsSearchCircle); obsSearchCircle = null; }
+              if (obsSearchPolygon) { map.removeLayer(obsSearchPolygon); obsSearchPolygon = null; }
+              let wkt;
             if (params.wkt) {
                 obsSearchPolygon = L.polygon(params.polygon, { color: '#c62828', weight: 2, fillOpacity: 0.1, interactive: false }).addTo(map);
                 wkt = params.wkt;


### PR DESCRIPTION
## Summary
- hide any previous search area circle when requesting GBIF observations
- keep observation search radius at 1km

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a27340808832cb2d91a08a4effea2