### PR TITLE
Unify species comparison and location

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="fr" data-theme="dark">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Comparaison des espèces</title>
+    <link rel="manifest" href="manifest.json">
+    <link rel="icon" href="icons/icon-192.png">
+    <script defer src="ui.js"></script>
+    <script defer src="app.js"></script>
+    <script defer src="compare.js"></script>
+    <link rel="stylesheet" href="style.css">
+    <style>
+       .subtabs { display:flex; gap:.5rem; margin-bottom:1rem; }
+       .subtab { flex:1; padding:0.5rem; background:none; border:1px solid var(--border); border-radius:4px; cursor:pointer; }
+       .subtab.active { background: var(--primary); color:#fff; }
+       .subtab-content { display:none; }
+       .subtab-content.active { display:block; }
+       iframe { width:100%; height:80vh; border:none; }
+    </style>
+</head>
+<body>
+   <nav class="tabs-container">
+      <div class="tabs">
+         <button class="tab" onclick="window.location.href='index.html'">Identification</button>
+         <button class="tab" onclick="window.location.href='biblio-patri.html'">Biblio Patri</button>
+         <button class="tab" onclick="window.location.href='contexte.html'">Contexte éco</button>
+      </div>
+   </nav>
+   <main style="padding:1rem;">
+      <div class="subtabs">
+         <button class="subtab active" data-target="carac-tab">Caractéristiques</button>
+         <button class="subtab" data-target="local-tab">Localisation</button>
+      </div>
+      <div id="carac-tab" class="subtab-content active">
+         <div id="comparison-results"></div>
+      </div>
+      <div id="local-tab" class="subtab-content">
+         <iframe id="map-iframe" title="Carte de localisation"></iframe>
+      </div>
+   </main>
+</body>
+</html>

--- a/compare.js
+++ b/compare.js
@@ -1,0 +1,67 @@
+document.addEventListener('DOMContentLoaded', async () => {
+    document.querySelectorAll('.subtab').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.subtab').forEach(b => b.classList.remove('active'));
+            document.querySelectorAll('.subtab-content').forEach(c => c.classList.remove('active'));
+            btn.classList.add('active');
+            const target = document.getElementById(btn.dataset.target);
+            if (target) target.classList.add('active');
+        });
+    });
+
+    await loadData();
+
+    const stored = localStorage.getItem('comparisonSpeciesData');
+    let speciesData = [];
+    if (stored) {
+        try { speciesData = JSON.parse(stored); } catch(e) { speciesData = []; }
+    }
+
+    const speciesNames = speciesData.map(s => s.species).join(',');
+    const iframe = document.getElementById('map-iframe');
+    if (iframe) {
+        iframe.src = `carte_interactive/map_view.html?species=${encodeURIComponent(speciesNames)}`;
+    }
+
+    const resultsDiv = document.getElementById('comparison-results');
+    if (!resultsDiv) return;
+
+    if (speciesData.length < 2) {
+        resultsDiv.innerHTML = '<p>Sélectionnez au moins deux espèces pour la comparaison.</p>';
+        return;
+    }
+
+    resultsDiv.innerHTML = '<i>Analyse en cours...</i>';
+    const comparisonText = await getComparisonFromGemini(speciesData);
+    const { intro, tableMarkdown, summary } = parseComparisonText(comparisonText);
+    const tableHtml = markdownTableToHtml(tableMarkdown);
+    resultsDiv.innerHTML = `
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem;">
+            <h2 style="margin:0;color:var(--primary);">Analyse Comparative des Espèces</h2>
+        </div>
+        <hr style="border:none;border-top:1px solid var(--border);margin:1rem 0;">
+        <div id="comparison-table-content"><p>${intro}</p>${tableHtml}</div>
+        <div id="comparison-summary" style="margin-top:1rem;display:flex;align-items:flex-start;gap:0.5rem;">
+            <p id="comparison-summary-text" style="margin:0;">${summary}</p>
+            <a href="#" id="comparison-tts-btn" title="Écouter la synthèse" style="flex-shrink:0;">
+                <img src="assets/Audio.png" alt="Écouter" class="logo-icon" style="height:32px;">
+            </a>
+        </div>`;
+
+    document.getElementById('comparison-tts-btn').addEventListener('click', async (e) => {
+        e.preventDefault();
+        const btn = e.currentTarget;
+        const textEl = document.getElementById('comparison-summary-text');
+        if (!textEl) return;
+        btn.innerHTML = '<i>...</i>';
+        btn.style.pointerEvents = 'none';
+        const audioData = await synthesizeSpeech(textEl.innerText);
+        if (audioData) {
+            playAudioFromBase64(audioData);
+        } else {
+            showInfoModal('Échec de la synthèse audio', "La conversion du texte en audio a échoué.");
+        }
+        btn.innerHTML = '<img src="assets/Audio.png" alt="Écouter" class="logo-icon" style="height:32px;">';
+        btn.style.pointerEvents = 'auto';
+    });
+});


### PR DESCRIPTION
## Summary
- replace "Carte de localisation" and comparison buttons with a single "Comparer les espèces" action
- new `compare.html` page containing two tabs for AI comparison and GBIF map
- add companion script `compare.js`
- update comparison handler to open the new page and store selected species in `localStorage`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a29c022f4832c960f8f957cdea4de