### PR TITLE
Refactor eco context map

### DIFF
--- a/contexte.html
+++ b/contexte.html
@@ -49,45 +49,15 @@
       .main-content { flex: 1; padding: 1rem; max-width: var(--max-width); margin: 0 auto; width: 100%; display:flex; flex-direction:column; gap:0.5rem; }
       h1 { color: var(--primary); margin: 0 0 1.5rem; font-size: 1.6rem; text-align: center; }
       
-      /* Options de localisation */
-      .location-options { display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 0.5rem; }
-      .location-card { background: var(--card); border-radius: 8px; padding: 0.5rem 0.8rem; box-shadow: 0 2px 6px rgba(0,0,0,0.1); }
-      .location-card h2 { display:none; }
-      .location-card .icon { display:none; }
-      .search-inline{display:flex;gap:.5rem;align-items:center;}
-      .search-inline input[type="text"]{flex:1;padding:8px;border:1px solid var(--border);border-radius:4px;font-size:1rem;margin:0;}
-      .search-inline .action-button{width:auto;margin-top:0;white-space:nowrap;}
-      
       .action-button { padding: 10px 16px; background: var(--primary); color: white; border: none; border-radius: 6px; font-size: 1rem; cursor: pointer; transition: all 0.3s; width: 100%; }
       .action-button:hover { background: #2e7d32; transform: scale(1.02); }
       .action-button:disabled { background: #ccc; cursor: not-allowed; transform: none; }
       
       /* Carte interactive */
-      #map-container {
-         display: block; margin-top: 1rem; border-radius: 8px;
-         overflow: hidden; box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-         border:1px solid var(--border);
-      }
-      #map { height: 60vh; width: 100%; }
+      #map { height: 60vh; width: 100%; margin-top:1rem; border-radius:8px; border:1px solid var(--border); box-shadow:0 2px 6px rgba(0,0,0,0.1); }
       .map-fullwidth{margin-left:calc(50% - 50vw);margin-right:calc(50% - 50vw);width:100vw;}
       
-      /* Coordonnées sélectionnées */
-      .coordinates-display {
-         display: none; margin-top: 1rem; padding: 1rem;
-         background: rgba(46, 125, 50, 0.1); border-radius: 6px;
-         border:1px solid var(--border); text-align: center;
-      }
-      .coordinates-display span { font-weight: 600; color: var(--primary); }
-      .coords-actions{margin-top:.5rem;display:flex;justify-content:center;gap:.5rem;flex-wrap:wrap;}
-      .small-button{
-         padding:4px 8px;background:var(--primary);color:#fff;border:none;
-         border-radius:4px;font-size:.9rem;cursor:pointer;
-         transition:background .3s,transform .3s;
-      }
-      .small-button:hover{background:#2e7d32;transform:scale(1.05);}
-      
       /* Résultats */
-      .results-section { display: none; margin-top: 2rem; }
       .results-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1rem; margin-top: 1rem; }
       .result-card {
          background: var(--card); border-radius: 8px; padding: 1rem;
@@ -98,12 +68,6 @@
       .result-card a { display: inline-block; margin-top: 0.5rem; color: var(--primary); text-decoration: none; }
       .result-card a:hover { text-decoration: underline; }
 
-      /* Sous-onglets des résultats */
-      .subtabs { display:flex; gap:.5rem; margin-bottom:1rem; }
-      .subtab { flex:1; padding:0.5rem; background:none; border:1px solid var(--border); border-radius:4px; cursor:pointer; }
-      .subtab.active { background: var(--primary); color:#fff; }
-      .subtab-content { display:none; }
-      .subtab-content.active { display:block; }
       
       /* Chargement */
       .loading { display: none; text-align: center; margin: 2rem 0; }
@@ -122,7 +86,6 @@
       }
       
       @media (prefers-color-scheme:dark) {
-         .coordinates-display { background: rgba(46, 125, 50, 0.2); }
          .map-instruction { background: rgba(255, 255, 255, 0.15); }
       }
    </style>
@@ -139,66 +102,15 @@
    <div class="main-content">
       <h1>🌿 Contexte environnemental</h1>
       
-      <div class="search-controls">
-         <div class="search-group address-group">
-            <input type="text" id="address-input" placeholder="Saisissez une adresse, une ville, un lieu...">
-            <button class="action-button" id="search-address">🔍 Rechercher</button>
-         </div>
-         <div class="button-grid">
-            <button class="action-button" id="use-geolocation">📍 Ma position</button>
-            <button class="action-button" id="choose-on-map">🗺️ Choisir sur la carte</button>
-         </div>
-      </div>
+      <div class="map-instruction" id="map-instruction">Cliquez droit ou appui long pour analyser un point</div>
+      <div id="map" class="map-fullwidth"></div>
 
-      <div id="map-container" class="map-fullwidth">
-         <div class="map-instruction" id="map-instruction">
-            Cliquez longuement pour sélectionner un point
-         </div>
-         <div id="map"></div>
-      </div>
-
-      <div class="coordinates-display" id="coordinates-display">
-         <div>
-            Coordonnées sélectionnées :
-            <span id="selected-coords">--</span>
-         </div>
-         <div class="coords-actions">
-            <button class="small-button" id="copy-coords">Copier</button>
-            <button class="small-button" id="open-gmaps">Google Maps</button>
-            <button class="small-button" id="reset-selection">Réinitialiser</button>
-         </div>
-      </div>
-
-      <button class="action-button" id="validate-location" style="display:none; margin-top:1rem;">
-         Valider cette localisation
-      </button>
-      
       <div class="loading" id="loading"></div>
 
-      <div class="results-section" id="results-section">
-        <div class="subtabs">
-           <button class="subtab active" data-target="zoning-tab">Zonage</button>
-           <button class="subtab" data-target="resources-tab">Ressources</button>
-        </div>
-        <button id="run-analysis" class="action-button" style="margin:0.5rem 0; display:none;">Lancer l'analyse</button>
-        <p id="altitude-info" style="text-align:center;margin:0.5rem 0;"></p>
-
-         <div id="zoning-tab" class="subtab-content active">
-            <h2 style="margin-top:2rem;">Carte interactive</h2>
-            <div id="layer-controls" style="margin-bottom:0.5rem;"></div>
-            <button id="measure-distance" class="small-button" style="display:none;margin-bottom:0.5rem;">Mesurer une distance</button>
-            <div id="env-map" class="map-fullwidth" style="height:80vh;display:none;"></div>
-         </div>
-
-         <div id="resources-tab" class="subtab-content">
-            <h2>Ressources environnementales</h2>
-            <p style="margin-bottom: 1rem; color: #666;">
-               Cliquez sur les liens ci-dessous pour explorer le contexte environnemental de la zone sélectionnée :
-            </p>
-            <div class="results-grid" id="results-grid">
-               </div>
-         </div>
-      </div>
+      <p id="altitude-info" style="text-align:center;margin:0.5rem 0;"></p>
+      <div id="layer-controls" style="margin-bottom:0.5rem;"></div>
+      <button id="measure-distance" class="small-button" style="display:none;margin-bottom:0.5rem;">Mesurer une distance</button>
+      <div class="results-grid" id="results-grid" style="display:none;"></div>
    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate a single interactive map for the eco context page
- show action popup on long press or right click
- run zoning or resources directly from the map

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a2dfe6ee4832caf1d37328660d915