### PR TITLE
Limit GBIF search radius to 500m

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -148,7 +148,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         return null;
     };
     const SEARCH_RADIUS_KM = 2;
-    const OBS_RADIUS_KM = 1;
+    const OBS_RADIUS_KM = 0.5;
     const ANALYSIS_MAX_RETRIES = 3;
     const RETRY_DELAY_MS = 3000;
     const FETCH_TIMEOUT_MS = 10000;


### PR DESCRIPTION
## Summary
- limit common flora search radius to 500 m in `biblio-patri.js`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_686a2f52a138832cbf4d249f38cdbd2e