### PR TITLE
Limit GBIF search radius to 500 m

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -148,7 +148,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         return null;
     };
     const SEARCH_RADIUS_KM = 2;
-    const OBS_RADIUS_KM = 1;
+    // Rayon de recherche pour la flore commune (500 m)
+    const OBS_RADIUS_KM = 0.5;
     const ANALYSIS_MAX_RETRIES = 3;
     const RETRY_DELAY_MS = 3000;
     const FETCH_TIMEOUT_MS = 10000;


### PR DESCRIPTION
## Summary
- narrow the observation search to 500 m when using the *Flore commune* option

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a2f5ad5dc832cbaac0701d908ae4e