### PR TITLE
Adjust compare tabs and lazy-load comparison

### DIFF
--- a/compare-page.js
+++ b/compare-page.js
@@ -1,23 +1,29 @@
+let caracLoaded = false;
+
 function showTab(name) {
     const isCarac = name === 'carac';
     document.getElementById('carac-content').style.display = isCarac ? 'block' : 'none';
     document.getElementById('loc-content').style.display = isCarac ? 'none' : 'block';
     document.getElementById('tab-carac').classList.toggle('active', isCarac);
     document.getElementById('tab-loc').classList.toggle('active', !isCarac);
+
+    if (isCarac && !caracLoaded) {
+        generateComparison();
+    }
 }
 
-document.addEventListener('DOMContentLoaded', async () => {
+async function generateComparison() {
     const stored = localStorage.getItem('comparisonData');
-    if (stored) {
-        try {
-            const speciesData = JSON.parse(stored);
-            if (Array.isArray(speciesData) && speciesData.length) {
-                const comparisonText = await getComparisonFromGemini(speciesData);
-                const { intro, tableMarkdown, summary } = parseComparisonText(comparisonText);
-                const tableHtml = markdownTableToHtml(tableMarkdown);
-                const container = document.getElementById('comparison-results-container');
-                container.style.display = 'block';
-                container.style.cssText = `
+    if (!stored || caracLoaded) return;
+    try {
+        const speciesData = JSON.parse(stored);
+        if (Array.isArray(speciesData) && speciesData.length) {
+            const comparisonText = await getComparisonFromGemini(speciesData);
+            const { intro, tableMarkdown, summary } = parseComparisonText(comparisonText);
+            const tableHtml = markdownTableToHtml(tableMarkdown);
+            const container = document.getElementById('comparison-results-container');
+            container.style.display = 'block';
+            container.style.cssText = `
                     margin-top: 2rem;
                     padding: 1.5rem;
                     background: var(--card, #ffffff);
@@ -25,7 +31,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     border-radius: 8px;
                     box-shadow: 0 2px 6px rgba(0,0,0,.05);
                 `;
-                container.innerHTML = `
+            container.innerHTML = `
                     <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem;">
                         <h2 style="margin:0;color:var(--primary,#388e3c);">Analyse Comparative des Espèces</h2>
                     </div>
@@ -37,29 +43,31 @@ document.addEventListener('DOMContentLoaded', async () => {
                             <img src="assets/Audio.png" alt="Écouter" class="logo-icon" style="height:32px;">
                         </a>
                     </div>`;
-                document.getElementById('comparison-tts-btn').addEventListener('click', async (e) => {
-                    e.preventDefault();
-                    const btn = e.currentTarget;
-                    const textElement = document.getElementById('comparison-summary-text');
-                    if (!textElement) return;
-                    const textToSynthesize = textElement.innerText;
-                    btn.innerHTML = '<i>...</i>';
-                    btn.style.pointerEvents = 'none';
-                    const audioData = await synthesizeSpeech(textToSynthesize);
-                    if (audioData) {
-                        playAudioFromBase64(audioData);
-                    } else {
-                        showInfoModal("Échec de la synthèse audio", "La conversion du texte en audio a échoué.");
-                    }
-                    btn.innerHTML = '<img src="assets/Audio.png" alt="Écouter" class="logo-icon" style="height:32px;">';
-                    btn.style.pointerEvents = 'auto';
-                });
-            }
-        } catch(e) {
-            console.error('Impossible de traiter les données de comparaison', e);
+            document.getElementById('comparison-tts-btn').addEventListener('click', async (e) => {
+                e.preventDefault();
+                const btn = e.currentTarget;
+                const textElement = document.getElementById('comparison-summary-text');
+                if (!textElement) return;
+                const textToSynthesize = textElement.innerText;
+                btn.innerHTML = '<i>...</i>';
+                btn.style.pointerEvents = 'none';
+                const audioData = await synthesizeSpeech(textToSynthesize);
+                if (audioData) {
+                    playAudioFromBase64(audioData);
+                } else {
+                    showInfoModal("Échec de la synthèse audio", "La conversion du texte en audio a échoué.");
+                }
+                btn.innerHTML = '<img src="assets/Audio.png" alt="Écouter" class="logo-icon" style="height:32px;">';
+                btn.style.pointerEvents = 'auto';
+            });
+            caracLoaded = true;
         }
+    } catch(e) {
+        console.error('Impossible de traiter les données de comparaison', e);
     }
+}
 
+document.addEventListener('DOMContentLoaded', () => {
     const params = new URLSearchParams(window.location.search);
     const speciesParam = params.get('species');
     if (speciesParam) {

--- a/compare.html
+++ b/compare.html
@@ -14,15 +14,15 @@
 <body>
     <nav class="tabs-container">
         <div class="tabs">
-            <button id="tab-carac" class="tab active" onclick="showTab('carac')">Caractéristiques</button>
-            <button id="tab-loc" class="tab" onclick="showTab('loc')">Localisation</button>
+            <button id="tab-loc" class="tab active" onclick="showTab('loc')">Localisation</button>
+            <button id="tab-carac" class="tab" onclick="showTab('carac')">Caractéristiques</button>
         </div>
     </nav>
     <div class="main-content">
-        <div id="carac-content" class="tab-content" style="display:block;">
+        <div id="carac-content" class="tab-content" style="display:none;">
             <div id="comparison-results-container"></div>
         </div>
-        <div id="loc-content" class="tab-content">
+        <div id="loc-content" class="tab-content" style="display:block;">
             <iframe id="map-frame" src="" style="width:100%;height:80vh;border:none;"></iframe>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- switch default tab to localisation and move to the left
- hide characteristic table by default
- defer AI comparison generation until user clicks "Caractéristiques"

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a30257118832cbe32304d74af6b6c