### PR TITLE
Add commune-based shapefile naming

### DIFF
--- a/shapefile.js
+++ b/shapefile.js
@@ -1,4 +1,4 @@
-window.downloadShapefile = function(featureCollection, prjString) {
+window.downloadShapefile = function(featureCollection, prjString, fileName = 'patrimonial_data') {
   const points = featureCollection.features.map(f => ({ x: f.geometry.coordinates[0], y: f.geometry.coordinates[1], props: f.properties }));
   if (points.length === 0) return;
 
@@ -188,7 +188,7 @@ window.downloadShapefile = function(featureCollection, prjString) {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = 'patrimonial_data.zip';
+  a.download = fileName + '.zip';
   a.click();
   setTimeout(() => URL.revokeObjectURL(url), 100);
 }


### PR DESCRIPTION
## Summary
- name shapefile download using commune and date
- store coordinates from last patrimonial analysis
- use stored coords to fetch commune info on download

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a3543f5e0832cb02add87ee33a2e3