### PR TITLE
Add navigation buttons to Biblio Patri page

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -34,6 +34,10 @@
             <button class="tab" onclick="window.location.href='contexte.html'">Contexte éco</button>
         </div>
     </nav>
+    <div class="nav-buttons">
+        <button id="scroll-map-btn" class="action-button">▲ Carte</button>
+        <button id="scroll-table-btn" class="action-button">▼ Tableau</button>
+    </div>
     <div class="main-content">
         <div class="search-controls">
             <div class="search-group address-group">

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -26,6 +26,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     const toggleLabelsBtn = document.getElementById('toggle-labels-btn');
     const downloadShapefileBtn = document.getElementById('download-shapefile-btn');
     const downloadContainer = document.getElementById('download-container');
+    const scrollMapBtn = document.getElementById('scroll-map-btn');
+    const scrollTableBtn = document.getElementById('scroll-table-btn');
 
     let trackingMap = null;
     let trackingButton = null;
@@ -831,6 +833,12 @@ const initializeSelectionMap = (coords) => {
     addressInput.addEventListener('keypress', (e) => e.key === 'Enter' && handleAddressSearch());
     downloadShapefileBtn.addEventListener('click', triggerShapefileDownload);
     toggleTrackingBtn.addEventListener('click', () => toggleLocationTracking(map, toggleTrackingBtn));
+    if (scrollMapBtn) {
+        scrollMapBtn.addEventListener('click', () => mapContainer.scrollIntoView({ behavior: 'smooth' }));
+    }
+    if (scrollTableBtn) {
+        scrollTableBtn.addEventListener('click', () => resultsContainer.scrollIntoView({ behavior: 'smooth' }));
+    }
     if (toggleLabelsBtn) {
         toggleLabelsBtn.addEventListener('click', toggleAnalysisLabels);
     }

--- a/style.css
+++ b/style.css
@@ -253,3 +253,13 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
     display: flex;
     gap: 0.5rem;
 }
+
+/* Navigation rapide carte/tableau dans Biblio Patri */
+.nav-buttons {
+    display: flex;
+    gap: 0.5rem;
+    margin: 0.5rem 0;
+}
+.nav-buttons .action-button {
+    flex: 1;
+}


### PR DESCRIPTION
## Summary
- add 'Carte' and 'Tableau' navigation buttons in biblio-patri.html
- style horizontal navigation buttons
- implement smooth scrolling to map and results sections

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a38d0a190832c83a3fbf4801220de