### PR TITLE
Add quick navigation buttons on patrimonial page

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -48,6 +48,11 @@
             </div>
         </div>
 
+        <div class="nav-buttons">
+            <button id="go-to-map-btn" class="action-button">↟ Carte</button>
+            <button id="go-to-table-btn" class="action-button">Tableau ↡</button>
+        </div>
+
         <div id="status" class="status-container"></div>
 
         <div id="map"></div>

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -26,6 +26,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     const toggleLabelsBtn = document.getElementById('toggle-labels-btn');
     const downloadShapefileBtn = document.getElementById('download-shapefile-btn');
     const downloadContainer = document.getElementById('download-container');
+    const goToMapBtn = document.getElementById('go-to-map-btn');
+    const goToTableBtn = document.getElementById('go-to-table-btn');
 
     let trackingMap = null;
     let trackingButton = null;
@@ -833,5 +835,15 @@ const initializeSelectionMap = (coords) => {
     toggleTrackingBtn.addEventListener('click', () => toggleLocationTracking(map, toggleTrackingBtn));
     if (toggleLabelsBtn) {
         toggleLabelsBtn.addEventListener('click', toggleAnalysisLabels);
+    }
+    if (goToMapBtn) {
+        goToMapBtn.addEventListener('click', () => {
+            mapContainer.scrollIntoView({ behavior: 'smooth' });
+        });
+    }
+    if (goToTableBtn) {
+        goToTableBtn.addEventListener('click', () => {
+            resultsContainer.scrollIntoView({ behavior: 'smooth' });
+        });
     }
 });

--- a/style.css
+++ b/style.css
@@ -95,6 +95,21 @@ h1 {
     width: 100%;
 }
 
+.nav-buttons {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+    position: sticky;
+    top: 3.5rem;
+    z-index: 90;
+    background: var(--card);
+    padding: 0.5rem 0;
+}
+.nav-buttons .action-button {
+    flex: 1;
+}
+
 
 
 #address-input {


### PR DESCRIPTION
## Summary
- add navigation buttons in the patrimonial page
- style these buttons and keep them sticky under the tabs
- hook buttons to scroll to the map or to the table

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a38d23864832cbd4807156a80bc4c