### PR TITLE
Fix search bar and button proportions

### DIFF
--- a/contexte.html
+++ b/contexte.html
@@ -61,6 +61,8 @@
       .action-button { padding: 10px 16px; background: var(--primary); color: white; border: none; border-radius: 6px; font-size: 1rem; cursor: pointer; transition: all 0.3s; width: 100%; }
       .action-button:hover { background: #2e7d32; transform: scale(1.02); }
       .action-button:disabled { background: #ccc; cursor: not-allowed; transform: none; }
+      .search-group.address-group input{flex:1;}
+      .search-group.address-group button{width:auto;flex:0 0 auto;}
       
       /* Carte interactive */
       #map-container {


### PR DESCRIPTION
## Summary
- tweak CSS in `contexte.html` so the address field flexes wider and the search button stays compact

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a3a3e0d6c832c98ca53b3fd9c3cd0