### PR TITLE
Add map/table navigation buttons

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -33,6 +33,10 @@
             <button class="tab" onclick="window.location.href='contexte.html'">Contexte éco</button>
         </div>
     </nav>
+    <div id="section-nav" class="section-nav" style="display:none;">
+        <button id="scroll-map-btn" class="action-button">Carte</button>
+        <button id="scroll-table-btn" class="action-button">Tableau</button>
+    </div>
     <div class="main-content">
         <div class="search-controls">
             <div class="search-group address-group">

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -26,6 +26,26 @@ document.addEventListener('DOMContentLoaded', async () => {
     const toggleLabelsBtn = document.getElementById('toggle-labels-btn');
     const downloadShapefileBtn = document.getElementById('download-shapefile-btn');
     const downloadContainer = document.getElementById('download-container');
+    const navContainer = document.getElementById('section-nav');
+    const scrollMapBtn = document.getElementById('scroll-map-btn');
+    const scrollTableBtn = document.getElementById('scroll-table-btn');
+    const addressGroup = document.querySelector('.address-group');
+
+    const showNavigation = () => {
+        if (navContainer) navContainer.style.display = 'flex';
+        if (addressGroup) addressGroup.style.display = 'none';
+    };
+
+    if (scrollMapBtn) {
+        scrollMapBtn.addEventListener('click', () => {
+            mapContainer.scrollIntoView({ behavior: 'smooth' });
+        });
+    }
+    if (scrollTableBtn) {
+        scrollTableBtn.addEventListener('click', () => {
+            resultsContainer.scrollIntoView({ behavior: 'smooth' });
+        });
+    }
 
     let trackingMap = null;
     let trackingButton = null;
@@ -94,10 +114,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         obsBtn.textContent = 'Flore commune';
         L.DomEvent.on(patrBtn, 'click', () => {
             map.closePopup();
+            showNavigation();
             runAnalysis({ latitude: latlng.lat, longitude: latlng.lng, ...extra });
         });
         L.DomEvent.on(obsBtn, 'click', () => {
             map.closePopup();
+            showNavigation();
             loadObservationsAt({ latitude: latlng.lat, longitude: latlng.lng, ...extra });
         });
         L.DomEvent.disableClickPropagation(container);

--- a/style.css
+++ b/style.css
@@ -253,3 +253,16 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
     display: flex;
     gap: 0.5rem;
 }
+
+/* Navigation pour accéder rapidement à la carte ou au tableau */
+.section-nav {
+    display: none;
+    position: sticky;
+    top: 0;
+    z-index: 90;
+    background: var(--card);
+    padding: 0.5rem;
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add quick navigation buttons to go to map or summary table
- style section nav buttons
- hide address search after running an analysis

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a3bfc6d2c832ca579024628547d5b