### PR TITLE
Ajout navigation carte/tableau

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -33,6 +33,10 @@
             <button class="tab" onclick="window.location.href='contexte.html'">Contexte éco</button>
         </div>
     </nav>
+    <div id="page-nav" class="page-nav" style="display:none;">
+        <button id="goto-map-btn" class="action-button">Carte</button>
+        <button id="goto-table-btn" class="action-button">Tableau</button>
+    </div>
     <div class="main-content">
         <div class="search-controls">
             <div class="search-group address-group">

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -18,6 +18,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     const statusDiv = document.getElementById('status');
     const resultsContainer = document.getElementById('results');
     const mapContainer = document.getElementById('map');
+    const pageNav = document.getElementById('page-nav');
+    const gotoMapBtn = document.getElementById('goto-map-btn');
+    const gotoTableBtn = document.getElementById('goto-table-btn');
     const addressInput = document.getElementById('address-input');
     const searchAddressBtn = document.getElementById('search-address-btn');
     const useGeolocationBtn = document.getElementById('use-geolocation-btn');
@@ -26,6 +29,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     const toggleLabelsBtn = document.getElementById('toggle-labels-btn');
     const downloadShapefileBtn = document.getElementById('download-shapefile-btn');
     const downloadContainer = document.getElementById('download-container');
+    const addressGroup = document.querySelector('.search-group.address-group');
+
+    const showNavigation = () => {
+        if (pageNav) pageNav.style.display = 'flex';
+        if (addressGroup) addressGroup.style.display = 'none';
+    };
 
     let trackingMap = null;
     let trackingButton = null;
@@ -537,6 +546,7 @@ const initializeSelectionMap = (coords) => {
 
     const runAnalysis = async (params) => {
         try {
+            showNavigation();
             lastAnalysisCoords = { latitude: params.latitude, longitude: params.longitude };
             resultsContainer.innerHTML = '';
             mapContainer.style.display = 'none';
@@ -765,6 +775,7 @@ const initializeSelectionMap = (coords) => {
 
       const loadObservationsAt = async (params) => {
           try {
+              showNavigation();
               if (!map) initializeSelectionMap(params);
               mapContainer.style.display = 'block';
               if (searchAreaLayer) {
@@ -833,5 +844,11 @@ const initializeSelectionMap = (coords) => {
     toggleTrackingBtn.addEventListener('click', () => toggleLocationTracking(map, toggleTrackingBtn));
     if (toggleLabelsBtn) {
         toggleLabelsBtn.addEventListener('click', toggleAnalysisLabels);
+    }
+    if (gotoMapBtn) {
+        gotoMapBtn.addEventListener('click', () => mapContainer.scrollIntoView({ behavior: 'smooth' }));
+    }
+    if (gotoTableBtn) {
+        gotoTableBtn.addEventListener('click', () => resultsContainer.scrollIntoView({ behavior: 'smooth' }));
     }
 });

--- a/style.css
+++ b/style.css
@@ -253,3 +253,15 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
     display: flex;
     gap: 0.5rem;
 }
+
+.page-nav {
+    position: sticky;
+    top: 3.5rem;
+    z-index: 90;
+    background: var(--card);
+    padding: 0.5rem;
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    border-bottom: 1px solid var(--border);
+}


### PR DESCRIPTION
## Summary
- add sticky navigation buttons to switch between map and summary
- hide address search section once analysis starts
- allow scrolling to map or table via new buttons

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a3bfee508832c96d364fde53fc473