### PR TITLE
Fix sticky navigation on heritage page

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -34,8 +34,8 @@
         </div>
     </nav>
     <div id="section-nav" class="section-nav" style="display:none;">
-        <button id="scroll-map-btn" class="action-button">Carte</button>
-        <button id="scroll-table-btn" class="action-button">Tableau</button>
+        <button id="scroll-map-btn" class="nav-tab">Carte</button>
+        <button id="scroll-table-btn" class="nav-tab">Tableau</button>
     </div>
     <div class="main-content">
         <div class="search-controls">

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -27,23 +27,42 @@ document.addEventListener('DOMContentLoaded', async () => {
     const downloadShapefileBtn = document.getElementById('download-shapefile-btn');
     const downloadContainer = document.getElementById('download-container');
     const navContainer = document.getElementById('section-nav');
+    const mainTabs = document.querySelector('.tabs-container');
     const scrollMapBtn = document.getElementById('scroll-map-btn');
     const scrollTableBtn = document.getElementById('scroll-table-btn');
     const addressGroup = document.querySelector('.address-group');
 
+    const updateSecondaryNav = () => {
+        if (navContainer && mainTabs) {
+            navContainer.style.top = mainTabs.offsetHeight + 'px';
+        }
+    };
+
     const showNavigation = () => {
         if (navContainer) navContainer.style.display = 'flex';
         if (addressGroup) addressGroup.style.display = 'none';
+        updateSecondaryNav();
+        if (scrollMapBtn && scrollTableBtn) {
+            scrollMapBtn.classList.add('active');
+            scrollTableBtn.classList.remove('active');
+        }
     };
+
+    updateSecondaryNav();
+    window.addEventListener('resize', updateSecondaryNav);
 
     if (scrollMapBtn) {
         scrollMapBtn.addEventListener('click', () => {
             mapContainer.scrollIntoView({ behavior: 'smooth' });
+            scrollMapBtn.classList.add('active');
+            if (scrollTableBtn) scrollTableBtn.classList.remove('active');
         });
     }
     if (scrollTableBtn) {
         scrollTableBtn.addEventListener('click', () => {
             resultsContainer.scrollIntoView({ behavior: 'smooth' });
+            scrollTableBtn.classList.add('active');
+            if (scrollMapBtn) scrollMapBtn.classList.remove('active');
         });
     }
 

--- a/style.css
+++ b/style.css
@@ -254,15 +254,43 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
     gap: 0.5rem;
 }
 
-/* Navigation pour accéder rapidement à la carte ou au tableau */
+/* Barre d'onglets secondaire (Carte/Tableau) */
 .section-nav {
     display: none;
     position: sticky;
     top: 0;
     z-index: 90;
     background: var(--card);
-    padding: 0.5rem;
+    border-bottom: 2px solid var(--border);
     display: flex;
     justify-content: center;
-    gap: 0.5rem;
+}
+
+.nav-tab {
+    flex: 1;
+    padding: 0.8rem 1rem;
+    text-align: center;
+    cursor: pointer;
+    background: none;
+    border: none;
+    font-size: 1rem;
+    color: var(--text);
+    transition: background 0.3s;
+    position: relative;
+}
+.nav-tab:hover {
+    background: rgba(56, 142, 60, 0.1);
+}
+.nav-tab.active {
+    color: var(--primary);
+    font-weight: 600;
+}
+.nav-tab.active::after {
+    content: '';
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--primary);
 }


### PR DESCRIPTION
## Summary
- add sticky secondary tabs for carte/tableau
- compute top offset dynamically relative to main tabs
- style the new navigation buttons like tabs

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a41648644832c9f64d3f875fb2485