### PR TITLE
Fix sticky sub-tabs in biblio view

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -33,8 +33,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     const addressGroup = document.querySelector('.address-group');
 
     const updateSecondaryNav = () => {
-        if (navContainer && mainTabs) {
-            navContainer.style.top = mainTabs.offsetHeight + 'px';
+        if (mainTabs) {
+            const offset = mainTabs.offsetHeight;
+            document.documentElement.style.setProperty('--section-nav-top', offset + 'px');
         }
     };
 

--- a/style.css
+++ b/style.css
@@ -258,12 +258,13 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
 .section-nav {
     display: none;
     position: sticky;
-    top: 0;
+    top: var(--section-nav-top, 0);
     z-index: 90;
     background: var(--card);
     border-bottom: 2px solid var(--border);
     display: flex;
     justify-content: center;
+    width: 100%;
 }
 
 .nav-tab {


### PR DESCRIPTION
## Summary
- keep secondary navigation below main tabs when scrolling
- use CSS variable for dynamic offset

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a42fdc4c4832cbb1c6e62262f5a25