### PR TITLE
Improve scroll target for map view

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -43,7 +43,7 @@
                 <input type="text" id="address-input" placeholder="Saisir une adresse, une ville, un lieu...">
                 <button id="search-address-btn" class="action-button">🔍 Rechercher</button>
             </div>
-            <div class="button-grid">
+            <div id="map-controls" class="button-grid">
                 <button id="use-geolocation-btn" class="action-button">📍 Ma position</button>
                 <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
                 <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -31,6 +31,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const scrollMapBtn = document.getElementById('scroll-map-btn');
     const scrollTableBtn = document.getElementById('scroll-table-btn');
     const addressGroup = document.querySelector('.address-group');
+    const mapControls = document.getElementById('map-controls');
 
     const updateSecondaryNav = () => {
         if (navContainer && mainTabs) {
@@ -53,7 +54,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     if (scrollMapBtn) {
         scrollMapBtn.addEventListener('click', () => {
-            mapContainer.scrollIntoView({ behavior: 'smooth' });
+            if (mapControls) {
+                mapControls.scrollIntoView({ behavior: 'smooth' });
+            } else {
+                mapContainer.scrollIntoView({ behavior: 'smooth' });
+            }
             scrollMapBtn.classList.add('active');
             if (scrollTableBtn) scrollTableBtn.classList.remove('active');
         });


### PR DESCRIPTION
## Summary
- allow the "Carte" tab to scroll to the map control buttons instead of top of page

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686a45c35420832c86de1c4db81fc502