### PR TITLE
Add ZNIEFF species integration

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -48,6 +48,7 @@
                 <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
                 <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
                 <button id="toggle-labels-btn" class="action-button">Masquer les étiquettes</button>
+                <button id="include-znieff-btn" class="action-button">Espèces ZNIEFF</button>
             </div>
         </div>
 

--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -48,7 +48,7 @@
                 <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
                 <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
                 <button id="toggle-labels-btn" class="action-button">Masquer les étiquettes</button>
-                <button id="include-znieff-btn" class="action-button">Espèces ZNIEFF</button>
+                <button id="include-znieff-btn" class="action-button" disabled>Espèces ZNIEFF</button>
             </div>
         </div>
 

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -492,6 +492,7 @@ const initializeSelectionMap = (coords) => {
 
     const displayResults = (occurrences, patrimonialMap, wkt) => {
         resultsContainer.innerHTML = '';
+        if (includeZnieffBtn) includeZnieffBtn.disabled = false;
         // Ne pas effacer les points précédents pour conserver l'historique
         if (Object.keys(patrimonialMap).length === 0) {
             setStatus(`Aucune occurrence d'espèce patrimoniale trouvée dans ce rayon de ${SEARCH_RADIUS_KM} km.`);
@@ -584,6 +585,8 @@ const initializeSelectionMap = (coords) => {
 
     const runAnalysis = async (params) => {
         try {
+            includeZnieff = false;
+            if (includeZnieffBtn) includeZnieffBtn.disabled = true;
             lastAnalysisCoords = { latitude: params.latitude, longitude: params.longitude };
             resultsContainer.innerHTML = '';
             mapContainer.style.display = 'none';


### PR DESCRIPTION
## Summary
- add a new `Espèces ZNIEFF` button to Biblio Patri page
- store last analysis geometry so we can rerun it
- allow including ZNIEFF rules in the analysis when requested

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6059dc6c832cbbc4e6d9c90143c2