### PR TITLE
Handle regional ZNIEFF as patrimonial

### DIFF
--- a/app.js
+++ b/app.js
@@ -1239,7 +1239,11 @@ async function runStatusAnalysis() {
         if (admCode === departement.code || admCode === region.code) { ruleApplies = true; }
       }
       if (ruleApplies) {
-        if (nonPatrimonialLabels.has(r.label) || type.includes('déterminante znieff')) return;
+        if (nonPatrimonialLabels.has(r.label)) return;
+        if (type.includes('déterminante znieff')) {
+          const isRegional = r.level && r.level.toLowerCase().includes('région');
+          if (!isRegional) return;
+        }
         const isRedList = type.includes('liste rouge');
         if (isRedList && nonPatrimonialRedlistCodes.has(r.code)) return;
         const ruleKey = `${r.nom}|${r.type}|${r.adm}`;

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -627,7 +627,11 @@ const initializeSelectionMap = (coords) => {
                             if (adminCode === departement.code || adminCode === region.code) { ruleApplies = true; }
                         }
                         if (ruleApplies) {
-                            if (nonPatrimonialLabels.has(row.label) || type.includes('déterminante znieff')) { continue; }
+                            if (nonPatrimonialLabels.has(row.label)) { continue; }
+                            if (type.includes('déterminante znieff')) {
+                                const isRegional = row.level && row.level.toLowerCase().includes('région');
+                                if (!isRegional) { continue; }
+                            }
                             const isRedList = type.includes('liste rouge');
                             if (isRedList && nonPatrimonialRedlistCodes.has(row.code)) { continue; }
                             const ruleKey = `${row.nom}|${row.type}|${row.adm}`;

--- a/netlify/functions/analyze-patrimonial-status.js
+++ b/netlify/functions/analyze-patrimonial-status.js
@@ -28,7 +28,7 @@ exports.handler = async function(event) {
 
 **Règles Impératives d'Analyse :**
 1.  **Précision Taxonomique :** Un statut s'applique UNIQUEMENT au taxon exact. Le statut d'une sous-espèce/variété ne s'applique pas à l'espèce parente.
-2.  **Définition de Patrimonialité :** Une espèce est patrimoniale si elle est protégée par la loi, ou menacée (NT, VU, EN, CR). Les statuts ZNIEFF, LC, DD, NA, NE ne sont PAS patrimoniaux.
+2.  **Définition de Patrimonialité :** Une espèce est patrimoniale si elle est protégée par la loi, menacée (NT, VU, EN, CR), ou déterminante ZNIEFF à l'échelle régionale. Les statuts ZNIEFF nationaux, LC, DD, NA, NE ne sont PAS patrimoniaux.
 3.  **Gestion des Conflits :** Si pour un taxon, une règle 'LC' et une règle de menace coexistent pour la même liste, 'LC' a priorité.
 
 **1. Analyse par Correspondance Directe :**


### PR DESCRIPTION
## Summary
- handle regional ZNIEFF rules client‑side
- allow regional ZNIEFF statuses in status analysis
- clarify server definition of patrimonial species

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a64d75590832ca28df3b2bf4f5ae0