### PR TITLE
Fix GBIF pagination limit

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -592,7 +592,9 @@ const initializeSelectionMap = (coords) => {
             }
             let allOccurrences = [];
             const maxPages = 20;
-            const limit = 1000;
+            // GBIF search offsets are limited to ~10000 records.
+            // Use a page size of 300 to safely paginate beyond 10 pages.
+            const limit = 300;
             setStatus(`Étape 2/4: Inventaire de la flore locale via GBIF... (Page 0/${maxPages})`, true);
             for (let page = 0; page < maxPages; page++) {
                 const offset = page * limit;


### PR DESCRIPTION
## Summary
- handle GBIF API pagination with a smaller page size

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a7751dc6c832c83caa8cbd67d5926