### PR TITLE
Fix README API key setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ Les fonctions `inpn-proxy.js` et `aura-images.js` utilisent ces modules.
 
 ## Configuration
 
-Éditez `app.js` et renseignez vos clés d'API :
+Définissez vos clés d'API dans des variables d'environnement, par exemple dans
+un fichier `.env` chargé par Netlify Dev :
 
-```javascript
-const API_KEY       = 'votre-cle-plantnet';
-const GEMINI_API_KEY= 'votre-cle-gemini';
-const TTS_API_KEY   = 'votre-cle-tts';
+```bash
+PLANTNET_API_KEY=<votre-clé-plantnet>
+GEMINI_API_KEY=<votre-clé-gemini>
+TTS_API_KEY=<votre-clé-tts>
 ```
+
+La fonction `api-proxy.js` lira ces variables pour appeler les services externes.
 
 ## Lancement en local
 


### PR DESCRIPTION
## Summary
- fix README instructions about API key setup now that keys are read from environment variables

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9f35cdf0832c96ab6ca816dd687f