### PR TITLE
Fix README installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,15 @@ Plantouille Express est une application web progressive qui aide à l'identifica
 
 ## Installation
 
-Dans `netlify/functions`, installez les dépendances requises :
+Installez les dépendances à la racine du projet :
 
 ```bash
-npm init -y
-npm install jsdom node-fetch
+npm install
 ```
 
-Les fonctions `inpn-proxy.js` et `aura-images.js` utilisent ces modules.
+`node-fetch` et `form-data` sont déjà renseignés dans `package.json` et
+servent aux fonctions `inpn-proxy.js` et `aura-images.js`. Inutile donc de
+créer un paquet séparé dans `netlify/functions` ni d'installer `jsdom`.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- remove outdated npm init instructions
- clarify that dependencies are installed at project root

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9f3c1498832cae85cc4f6e5409ec