### PR TITLE
Add env.example for Netlify functions

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,0 +1,6 @@
+# Example environment variables for Netlify functions
+# Copy this file to `.env` and fill in your API keys
+
+PLANTNET_API_KEY=
+GEMINI_API_KEY=
+TTS_API_KEY=


### PR DESCRIPTION
## Summary
- add `env.example` listing the API keys required by Netlify functions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9f63f898832c869e3cff0e4a5aca