### PR TITLE
Add test setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,13 @@ netlify dev
 
 ## Tests
 
-Le projet inclut une suite Jest. Installez les dépendances puis lancez :
+
+Le projet inclut une suite Jest. Pour faciliter l'exécution des tests sur
+toute plateforme, un script est fourni pour installer les dépendances et
+lancer Jest automatiquement :
 
 ```bash
-npm install
-npm test
+./scripts/setup-tests.sh
 ```
 
 ## Déploiement

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+# Installe les dépendances puis lance la suite de tests
+# Utilise npm ci pour une installation reproductible
+
+set -e
+
+# Installation
+npm ci
+
+# Lancement des tests
+npm test


### PR DESCRIPTION
## Summary
- add a helper script `setup-tests.sh` that installs packages and runs the Jest suite
- document the new script in README

## Testing
- `scripts/setup-tests.sh` *(fails: E403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_686a9f803ce8832c86cbdfea5444117f