### PR TITLE
Add serverless function tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ npm install
 npm test
 ```
 
+Les tests couvrent aussi les fonctions serverless présentes dans `netlify/functions` (`inpn-proxy.js`, `api-proxy.js`, ...).
+Une fois les dépendances installées, exécutez simplement `npm test` depuis la racine pour lancer l'ensemble de la suite.
+
 ## Déploiement
 
 Poussez le dépôt sur GitHub puis créez un site sur Netlify. Le fichier `netlify.toml` publie la racine du projet et active les fonctions sous `/.netlify/functions/`.

--- a/__tests__/analyze-patrimonial-status.test.js
+++ b/__tests__/analyze-patrimonial-status.test.js
@@ -1,0 +1,36 @@
+const { loadAnalyzeHandler } = require('../test-utils');
+
+describe('analyze-patrimonial-status handler', () => {
+  test('rejects non-POST requests', async () => {
+    const handler = loadAnalyzeHandler(jest.fn(), { GEMINI_API_KEY: 'x' });
+    const res = await handler({ httpMethod: 'GET' });
+    expect(res.statusCode).toBe(405);
+  });
+
+  test('returns 400 for invalid JSON', async () => {
+    const handler = loadAnalyzeHandler(jest.fn(), { GEMINI_API_KEY: 'x' });
+    const res = await handler({ httpMethod: 'POST', body: '{' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('returns patrimonial map on success', async () => {
+    const fetchMock = jest.fn((url) => {
+      if (url.startsWith('https://geo.api.gouv.fr')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([{ departement: { code: '42' }, region: { code: '84' } }])
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ candidates: [{ content: { parts: [{ text: '{"Abies alba":["protégée"]}' }] } }] })
+      });
+    });
+    const handler = loadAnalyzeHandler(fetchMock, { GEMINI_API_KEY: 'abc' });
+    const body = { relevantRules: [], uniqueSpeciesNames: ['Abies alba'], coords: { latitude: 1, longitude: 2 } };
+    const res = await handler({ httpMethod: 'POST', body: JSON.stringify(body) });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ 'Abies alba': ['protégée'] });
+  });
+});

--- a/__tests__/api-proxy.test.js
+++ b/__tests__/api-proxy.test.js
@@ -1,0 +1,63 @@
+const { loadApiProxyHandler } = require('../test-utils');
+
+class DummyFormData {
+  constructor() { this.append = jest.fn(); }
+  getHeaders() { return {}; }
+}
+
+describe('api-proxy handler', () => {
+  test('rejects non-POST requests', async () => {
+    const handler = loadApiProxyHandler(jest.fn());
+    const res = await handler({ httpMethod: 'GET' });
+    expect(res.statusCode).toBe(405);
+  });
+
+  test('returns 400 for invalid JSON', async () => {
+    const handler = loadApiProxyHandler(jest.fn());
+    const res = await handler({ httpMethod: 'POST', body: '{' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('returns 400 for invalid target', async () => {
+    const handler = loadApiProxyHandler(jest.fn());
+    const res = await handler({ httpMethod: 'POST', body: JSON.stringify({ target: 'foo' }) });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('forwards gemini requests', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true })
+    });
+    const handler = loadApiProxyHandler(fetchMock, { GEMINI_API_KEY: 'abc' });
+    const payload = { foo: 'bar' };
+    const res = await handler({ httpMethod: 'POST', body: JSON.stringify({ target: 'gemini', payload }) });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('gemini-2.5-flash-lite-preview-06-17:generateContent?key=abc'),
+      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) }
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe(JSON.stringify({ ok: true }));
+  });
+
+  test('handles PlantNet images', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true })
+    });
+    let formInstance;
+    class TestForm extends DummyFormData {
+      constructor() { super(); formInstance = this; }
+    }
+    const handler = loadApiProxyHandler(fetchMock, { PLANTNET_API_KEY: 'abc' }, TestForm);
+    const img = { name: 'test.jpg', organ: 'leaf', dataUrl: 'data:image/jpeg;base64,aGVsbG8=' };
+    await handler({ httpMethod: 'POST', body: JSON.stringify({ target: 'plantnet', payload: { images: [img] } }) });
+    expect(formInstance.append).toHaveBeenCalledWith('organs', img.organ);
+    const secondCall = formInstance.append.mock.calls[1];
+    expect(secondCall[0]).toBe('images');
+    expect(secondCall[1]).toBeInstanceOf(Buffer);
+    expect(secondCall[2]).toBe(img.name);
+  });
+});


### PR DESCRIPTION
## Summary
- extend Jest utilities to load `api-proxy` and `analyze-patrimonial-status`
- test these serverless functions
- mention serverless tests in README

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9f68f978832c9b60d8bbe5f8b457