### PR TITLE
Add ESLint and Prettier config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2021": true,
+    "jest": true
+  },
+  "extends": ["eslint:recommended", "plugin:prettier/recommended"],
+  "parserOptions": {
+    "ecmaVersion": "latest"
+  },
+  "rules": {
+    "no-unused-vars": "warn",
+    "no-console": "off",
+    "eqeqeq": ["warn", "always"]
+  }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 2,
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "none",
+  "printWidth": 100
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Application d'aide à l'identification de la flore",
   "main": "app.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "lint": "eslint .",
+    "format": "prettier --write ."
   },
   "author": "Robin Wojcik",
   "license": "ISC",
@@ -16,6 +18,10 @@
     "form-data": "^4.0.0"
   },
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "eslint": "^8.50.0",
+    "prettier": "^3.2.5",
+    "eslint-plugin-prettier": "^5.0.1",
+    "eslint-config-prettier": "^9.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `.eslintrc.json` with basic rules
- add `.prettierrc` for consistent formatting
- add lint and format scripts to `package.json`
- declare ESLint/Prettier dev dependencies

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm install --save-dev eslint prettier eslint-plugin-prettier eslint-config-prettier` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686a9fa04350832cbc144304559a3890