### PR TITLE
Add inline status icons

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -215,15 +215,14 @@ let rulesByTaxonIndex = new Map();
     const OLD_REGIONS_TO_DEPARTMENTS = { 'Alsace': ['67', '68'], 'Aquitaine': ['24', '33', '40', '47', '64'], 'Auvergne': ['03', '15', '43', '63'], 'Basse-Normandie': ['14', '50', '61'], 'Bourgogne': ['21', '58', '71', '89'], 'Champagne-Ardenne': ['08', '10', '51', '52'], 'Franche-Comté': ['25', '39', '70', '90'], 'Haute-Normandie': ['27', '76'], 'Languedoc-Roussillon': ['11', '30', '34', '48', '66'], 'Limousin': ['19', '23', '87'], 'Lorraine': ['54', '55', '57', '88'], 'Midi-Pyrénées': ['09', '12', '31', '32', '46', '65', '81', '82'], 'Nord-Pas-de-Calais': ['59', '62'], 'Picardie': ['02', '60', '80'], 'Poitou-Charentes': ['16', '17', '79', '86'], 'Rhône-Alpes': ['01', '07', '26', '38', '42', '69', '73', '74'] };
     const ADMIN_NAME_TO_CODE_MAP = { "France": "FR", "Ain": "01", "Aisne": "02", "Allier": "03", "Alpes-de-Haute-Provence": "04", "Hautes-Alpes": "05", "Alpes-Maritimes": "06", "Ardèche": "07", "Ardennes": "08", "Ariège": "09", "Aube": "10", "Aude": "11", "Aveyron": "12", "Bouches-du-Rhône": "13", "Calvados": "14", "Cantal": "15", "Charente": "16", "Charente-Maritime": "17", "Cher": "18", "Corrèze": "19", "Corse-du-Sud": "2A", "Haute-Corse": "2B", "Côte-d'Or": "21", "Côtes-d'Armor": "22", "Creuse": "23", "Dordogne": "24", "Doubs": "25", "Drôme": "26", "Eure": "27", "Eure-et-Loir": "28", "Finistère": "29", "Gard": "30", "Haute-Garonne": "31", "Gers": "32", "Gironde": "33", "Hérault": "34", "Ille-et-Vilaine": "35", "Indre": "36", "Indre-et-Loire": "37", "Isère": "38", "Jura": "39", "Landes": "40", "Loir-et-Cher": "41", "Loire": "42", "Haute-Loire": "43", "Loire-Atlantique": "44", "Loiret": "45", "Lot": "46", "Lot-et-Garonne": "47", "Lozère": "48", "Maine-et-Loire": "49", "Manche": "50", "Marne": "51", "Haute-Marne": "52", "Mayenne": "53", "Meurthe-et-Moselle": "54", "Meuse": "55", "Morbihan": "56", "Moselle": "57", "Nièvre": "58", "Nord": "59", "Oise": "60", "Orne": "61", "Pas-de-Calais": "62", "Puy-de-Dôme": "63", "Pyrénées-Atlantiques": "64", "Hautes-Pyrénées": "65", "Pyrénées-Orientales": "66", "Bas-Rhin": "67", "Haut-Rhin": "68", "Rhône": "69", "Haute-Saône": "70", "Saône-et-Loire": "71", "Sarthe": "72", "Savoie": "73", "Haute-Savoie": "74", "Paris": "75", "Seine-Maritime": "76", "Seine-et-Marne": "77", "Yvelines": "78", "Deux-Sèvres": "79", "Somme": "80", "Tarn": "81", "Tarn-et-Garonne": "82", "Var": "83", "Vaucluse": "84", "Vendée": "85", "Vienne": "86", "Haute-Vienne": "87", "Vosges": "88", "Yonne": "89", "Territoire de Belfort": "90", "Essonne": "91", "Hauts-de-Seine": "92", "Seine-Saint-Denis": "93", "Val-de-Marne": "94", "Val-d'Oise": "95", "Auvergne-Rhône-Alpes": "84", "Bourgogne-Franche-Comté": "27", "Bretagne": "53", "Centre-Val de Loire": "24", "Corse": "94", "Grand Est": "44", "Hauts-de-France": "32", "Île-de-France": "11", "Normandie": "28", "Nouvelle-Aquitaine": "75", "Occitanie": "76", "Pays de la Loire": "52", "Provence-Alpes-Côte d'Azur": "93", "Guadeloupe": "01", "Martinique": "02", "Guyane": "03", "La Réunion": "04", "Mayotte": "06" };
 
-    const setStatus = (message, isLoading = false) => {
+    const setStatus = (message = '', withIcons = false) => {
         statusDiv.innerHTML = '';
-        if (isLoading) {
-            const worker = document.createElement('div');
-            worker.className = 'robot-working';
-            worker.innerHTML = '<span class="robot">🤖</span><span class="gear">⚙️</span>';
-            statusDiv.appendChild(worker);
+        if (withIcons) {
+            statusDiv.innerHTML =
+                `<span class="robot-working"><span class="robot">🤖</span><span class="gear">⚙️</span></span>${message}`;
+        } else {
+            statusDiv.textContent = message;
         }
-        if (message) statusDiv.innerHTML += `<p>${message}</p>`;
     };
 
     const fetchWithRetry = async (url, options = {}, maxRetries = ANALYSIS_MAX_RETRIES) => {
@@ -860,7 +859,7 @@ const initializeSelectionMap = (coords) => {
                 observationsLayerGroup.addLayer(m);
             }
         });
-        statusDiv.innerHTML = `${floraOccs.length} observation(s) de flore trouvée(s).`;
+        setStatus(`${floraOccs.length} observation(s) de flore trouvée(s).`, true);
     };
 
     const triggerShapefileDownload = async () => {
@@ -912,7 +911,7 @@ const initializeSelectionMap = (coords) => {
                 wkt = 'POLYGON((' + Array.from({length:33},(_,i)=>{const a=i*2*Math.PI/32,r=111.32*Math.cos(params.latitude*Math.PI/180);return `${(params.longitude+OBS_RADIUS_KM/r*Math.cos(a)).toFixed(5)} ${(params.latitude+OBS_RADIUS_KM/111.132*Math.sin(a)).toFixed(5)}`;}).join(', ') + '))';
                 map.fitBounds(obsSearchCircle.getBounds());
             }
-            statusDiv.textContent = 'Recherche des occurrences GBIF...';
+            setStatus('Recherche des occurrences GBIF...', true);
 
             const limit = 300;
             let offset = 0;
@@ -932,7 +931,7 @@ const initializeSelectionMap = (coords) => {
             }
 
             if (allResults.length === 0) {
-                statusDiv.textContent = 'Aucune observation trouvée.';
+                setStatus('Aucune observation trouvée.', true);
                 return;
             }
 
@@ -945,7 +944,7 @@ const initializeSelectionMap = (coords) => {
                 obsLayerAddedToControl = true;
             }
         } catch(error) {
-            statusDiv.textContent = `Erreur : ${error.message}`;
+            setStatus(`Erreur : ${error.message}`, true);
         }
     };
 

--- a/style.css
+++ b/style.css
@@ -130,7 +130,7 @@ h1 {
     justify-content: center;
     font-size: 1.5rem;
     gap: 0.25rem;
-    margin-bottom: 0.25rem;
+    margin-right: 0.25rem;
 }
 .robot-working .gear {
     display: inline-block;


### PR DESCRIPTION
## Summary
- update status icon CSS so icons sit next to messages
- show working icons beside status text in `biblio-patri.js`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_686bb42cedfc832c83424560a36514f0