### PR TITLE
Improve status messages

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -222,16 +222,16 @@ let rulesByTaxonIndex = new Map();
         const container = document.createElement('span');
         container.className = 'status-line';
 
+        const text = document.createElement('span');
+        text.textContent = message;
+        container.appendChild(text);
+
         if (showIcons) {
             const worker = document.createElement('span');
             worker.className = 'robot-working';
             worker.innerHTML = '<span class="robot">🤖</span><span class="gear">⚙️</span>';
             container.appendChild(worker);
         }
-
-        const text = document.createElement('span');
-        text.textContent = message;
-        container.appendChild(text);
 
         statusDiv.appendChild(container);
     };

--- a/style.css
+++ b/style.css
@@ -135,9 +135,8 @@ h1 {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: 1.5rem;
+    font-size: 1rem;
     gap: 0.25rem;
-    margin-bottom: 0.25rem;
 }
 .robot-working .gear {
     display: inline-block;


### PR DESCRIPTION
## Summary
- keep status messages on one line by placing the activity icons after the text
- shrink status icons to avoid excessive vertical space

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb77440e8832cafcfb608590c5190