### PR TITLE
Automate serverless tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,5 +10,4 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
-      - run: npm install
-      - run: npm test
+      - run: sh ./scripts/setup-tests.sh


### PR DESCRIPTION
## Summary
- use the helper script in CI so serverless function tests run automatically

## Testing
- `sh ./scripts/setup-tests.sh` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_686bb9b34310832cbe0ad11ff5abfd46