### PR TITLE
Automate service worker cache version

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ netlify dev
 
 ## Tests
 
-
 Le projet inclut une suite Jest. Pour faciliter l'exécution des tests sur
 toute plateforme, un script est fourni pour installer les dépendances et
 lancer Jest automatiquement :
@@ -66,6 +65,8 @@ Une fois les dépendances installées, exécutez simplement `npm test` depuis la
 ## Déploiement
 
 Poussez le dépôt sur GitHub puis créez un site sur Netlify. Le fichier `netlify.toml` publie la racine du projet et active les fonctions sous `/.netlify/functions/`.
+Avant chaque mise en ligne, exécutez `npm run update-sw-cache` afin de
+synchroniser le numéro de cache du service worker avec la version indiquée dans `package.json`.
 
 ## Fonctionnalités principales
 
@@ -75,4 +76,3 @@ Poussez le dépôt sur GitHub puis créez un site sur Netlify. Le fichier `netli
 - carte contextuelle avec couches IGN (réserves, zones humides, etc.)
 - recherche par trigramme et suggestions via TaxRef Match
 - comparaison d'espèces et synthèse vocale optionnelle
-

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "jest",
     "lint": "eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "update-sw-cache": "node scripts/update-sw-cache.js"
   },
   "author": "Robin Wojcik",
   "license": "ISC",

--- a/scripts/update-sw-cache.js
+++ b/scripts/update-sw-cache.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+const pkg = require('../package.json');
+const swPath = path.join(__dirname, '..', 'sw.js');
+const cacheName = `plantid-v${pkg.version}`;
+
+const swData = fs.readFileSync(swPath, 'utf8');
+const updated = swData.replace(/const CACHE_NAME = "[^"]+";/, `const CACHE_NAME = "${cacheName}";`);
+fs.writeFileSync(swPath, updated);
+console.log(`Updated CACHE_NAME to ${cacheName}`);


### PR DESCRIPTION
## Summary
- add `update-sw-cache` script to package.json
- document running the cache update script before deployment
- provide `scripts/update-sw-cache.js` to update CACHE_NAME using the version in `package.json`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bba1131b8832cb0b2a25aee110f86