### PR TITLE
Display comparison map full width

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -1,30 +1,52 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr" data-theme="dark">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Comparaison des espèces</title>
-    <link rel="manifest" href="manifest.json">
-    <link rel="icon" href="icons/icon-192.png">
-    <link rel="stylesheet" href="style.css">
+    <link rel="manifest" href="manifest.json" />
+    <link rel="icon" href="icons/icon-192.png" />
+    <link rel="stylesheet" href="style.css" />
+    <style>
+      .map-fullwidth {
+        margin-left: calc(50% - 50vw);
+        margin-right: calc(50% - 50vw);
+        width: 100vw;
+      }
+      body.compare-page .main-content {
+        padding: 0;
+      }
+      body.compare-page #loc-content {
+        padding: 0;
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+        background: none;
+      }
+    </style>
     <script defer src="ui.js"></script>
     <script defer src="app.js"></script>
     <script defer src="compare-page.js"></script>
-</head>
-<body>
+  </head>
+  <body class="compare-page">
     <nav class="tabs-container">
-        <div class="tabs">
-            <button id="tab-loc" class="tab active" onclick="showTab('loc')">Localisation</button>
-            <button id="tab-carac" class="tab" onclick="showTab('carac')">Caractéristiques</button>
-        </div>
+      <div class="tabs">
+        <button id="tab-loc" class="tab active" onclick="showTab('loc')">Localisation</button>
+        <button id="tab-carac" class="tab" onclick="showTab('carac')">Caractéristiques</button>
+      </div>
     </nav>
     <div class="main-content">
-        <div id="carac-content" class="tab-content" style="display:none;">
-            <div id="comparison-results-container"></div>
-        </div>
-        <div id="loc-content" class="tab-content" style="display:block;">
-            <iframe id="map-frame" src="" style="width:100%;height:80vh;border:none;"></iframe>
-        </div>
+      <div id="carac-content" class="tab-content" style="display: none">
+        <div id="comparison-results-container"></div>
+      </div>
+      <div id="loc-content" class="tab-content" style="display: block">
+        <iframe
+          id="map-frame"
+          class="map-fullwidth"
+          src=""
+          style="width: 100%; height: 80vh; border: none"
+        ></iframe>
+      </div>
     </div>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- make comparison map container full width
- remove padding and borders around the map iframe

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npx prettier --write compare.html`

------
https://chatgpt.com/codex/tasks/task_e_686d5f75eac8832c9e4f225d3065708b