### PR TITLE
Improve polygon drawing UX

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -841,15 +841,49 @@ const initializeSelectionMap = (coords) => {
             } catch (e) {}
         }
         initializeSelectionMap(center);
-        setStatus('Tracez un polygone pour définir la zone de recherche.', false);
-        const drawer = new L.Draw.Polygon(map, { shapeOptions: { color: '#c62828' } });
-        drawer.enable();
-        map.once(L.Draw.Event.CREATED, (e) => {
-            const latlngs = e.layer.getLatLngs()[0];
+        setStatus('Volume + : ajoute un point \u2013 Volume - : retire le dernier. Validez pour terminer.', false);
+
+        const container = map.getContainer();
+        const target = L.DomUtil.create('div', 'map-target', container);
+        const validateBtn = L.DomUtil.create('button', 'action-button validate-polygon-btn', container);
+        validateBtn.textContent = 'Valider';
+
+        let points = [];
+        let preview = L.polyline([], { color: '#c62828' }).addTo(map);
+
+        const updatePreview = () => {
+            preview.setLatLngs(points);
+        };
+
+        const keyHandler = (e) => {
+            if (e.key === 'AudioVolumeUp' || e.key === 'VolumeUp') {
+                e.preventDefault();
+                points.push(map.getCenter());
+                updatePreview();
+            } else if (e.key === 'AudioVolumeDown' || e.key === 'VolumeDown') {
+                e.preventDefault();
+                points.pop();
+                updatePreview();
+            }
+        };
+
+        const finish = () => {
+            document.removeEventListener('keydown', keyHandler);
+            if (target.parentNode) target.parentNode.removeChild(target);
+            if (validateBtn.parentNode) validateBtn.parentNode.removeChild(validateBtn);
+            map.removeLayer(preview);
+            if (points.length < 3) {
+                setStatus('Au moins trois points sont n\u00e9cessaires.', false);
+                return;
+            }
+            const latlngs = points;
             const centroid = centroidOf(latlngs);
             const wkt = polygonToWkt(latlngs);
             showChoicePopup(L.latLng(centroid.latitude, centroid.longitude), { wkt, polygon: latlngs });
-        });
+        };
+
+        document.addEventListener('keydown', keyHandler);
+        validateBtn.addEventListener('click', finish);
     };
 
     let obsSearchCircle = null;

--- a/style.css
+++ b/style.css
@@ -319,3 +319,46 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
     height: 2px;
     background: var(--primary);
 }
+
+/* Cible centrale pour le dessin tactile */
+.map-target {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 28px;
+    height: 28px;
+    margin-left: -14px;
+    margin-top: -14px;
+    border-radius: 50%;
+    border: 2px solid #c62828;
+    pointer-events: none;
+    z-index: 1000;
+}
+.map-target::before,
+.map-target::after {
+    content: '';
+    position: absolute;
+    background: #c62828;
+}
+.map-target::before {
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 2px;
+    transform: translateX(-50%);
+}
+.map-target::after {
+    left: 0;
+    right: 0;
+    top: 50%;
+    height: 2px;
+    transform: translateY(-50%);
+}
+
+.validate-polygon-btn {
+    position: absolute;
+    bottom: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1001;
+}


### PR DESCRIPTION
## Summary
- enable tactile polygon drawing with volume buttons
- add crosshair styles for polygon capture

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d5f196d58832cb2418b0166bc6398