### PR TITLE
Display comparison maps full width

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -11,7 +11,7 @@
     <script defer src="app.js"></script>
     <script defer src="compare-page.js"></script>
 </head>
-<body>
+<body class="compare">
     <nav class="tabs-container">
         <div class="tabs">
             <button id="tab-loc" class="tab active" onclick="showTab('loc')">Localisation</button>

--- a/style.css
+++ b/style.css
@@ -74,6 +74,19 @@ h1 {
     padding: 1rem;
 }
 
+/* Suppression des marges et bordures pour l'affichage plein écran des cartes */
+body.compare .main-content {
+    padding: 0;
+}
+
+body.compare #loc-content.tab-content {
+    padding: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    background: none;
+}
+
 .search-controls {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- mark comparison page body with `compare` class
- remove padding/borders so comparison maps span entire width

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d5f726800832cb0f144abca6c7efa