### PR TITLE
Add browser automation extension

### DIFF
--- a/chrome-extension/arcgis.js
+++ b/chrome-extension/arcgis.js
@@ -1,0 +1,6 @@
+(function() {
+  const xpath = "//button[normalize-space()='OK']";
+  const res = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+  const btn = res.singleNodeValue;
+  if (btn) btn.click();
+})();

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,0 +1,25 @@
+function latLonToWebMercator(lat, lon) {
+  const R = 6378137;
+  const x = R * (lon * Math.PI / 180);
+  const y = R * Math.log(Math.tan(Math.PI / 4 + lat * Math.PI / 360));
+  return { x, y };
+}
+
+function openArcGis(lat, lon) {
+  const { x, y } = latLonToWebMercator(lat, lon);
+  const b = 1000;
+  const url = `https://www.arcgis.com/apps/webappviewer/index.html?id=bece6e542e4c42e0ba9374529c7de44c&extent=${x-b},${y-b},${x+b},${y+b},102100`;
+  chrome.tabs.create({ url });
+}
+
+function openGeoportail(lat, lon) {
+  const url = `https://www.geoportail.gouv.fr/carte?c=${lon},${lat}&z=15&l0=ORTHOIMAGERY.ORTHOPHOTOS::GEOPORTAIL:OGC:WMTS(1)&l1=AGRICULTURE.CARTE.PEDOLOGIQUE::GEOPORTAIL:OGC:WMS(0.5)&permalink=yes`;
+  chrome.tabs.create({ url });
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg && msg.type === 'open-maps') {
+    openArcGis(msg.lat, msg.lon);
+    openGeoportail(msg.lat, msg.lon);
+  }
+});

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,30 @@
+{
+  "name": "FloreApp Automation",
+  "description": "Ouvre automatiquement les cartes de végétation potentielle et des sols",
+  "manifest_version": 3,
+  "version": "1.0",
+  "permissions": ["tabs", "scripting"],
+  "host_permissions": [
+    "https://www.arcgis.com/*",
+    "https://www.geoportail.gouv.fr/*",
+    "https://*.netlify.app/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://*.netlify.app/*"],
+      "js": ["page-script.js"],
+      "run_at": "document_start"
+    },
+    {
+      "matches": ["https://www.arcgis.com/*"],
+      "js": ["arcgis.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "action": {
+    "default_title": "FloreApp Automation"
+  }
+}

--- a/chrome-extension/page-script.js
+++ b/chrome-extension/page-script.js
@@ -1,0 +1,8 @@
+window.addEventListener('message', (e) => {
+  if (e.source !== window) return;
+  const { type, lat, lon } = e.data || {};
+  if (type === 'open-maps') {
+    chrome.runtime.sendMessage({ type: 'open-maps', lat, lon });
+    window.postMessage({ type: 'open-maps-ack' }, '*');
+  }
+});

--- a/contexte.html
+++ b/contexte.html
@@ -10,6 +10,7 @@
    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
    <script defer src="ui.js"></script>
    <script defer src="contexte.js"></script>
+   <script defer src="extension-bridge.js"></script>
    <script defer src="sw-register.js"></script>
    <link rel="stylesheet" href="style.css">
    <style>
@@ -163,6 +164,7 @@
          <div id="env-map" class="map-fullwidth" style="height:80vh;"></div>
       </div>
       <button id="measure-distance" class="small-button" style="display:none;margin-bottom:0.5rem;">Mesurer une distance</button>
+      <button id="open-external-maps" class="small-button" style="margin-bottom:0.5rem;">Cartes végétation/sols</button>
       <div class="results-grid" id="results-grid" style="display:none;"></div>
    </div>
 </body>

--- a/contexte.js
+++ b/contexte.js
@@ -285,6 +285,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (e.key === 'Enter') searchAddress();
     });
     document.getElementById('measure-distance').addEventListener('click', toggleMeasure);
+    const extBtn = document.getElementById('open-external-maps');
+    if (extBtn) extBtn.addEventListener('click', launchExternalMaps);
     initializeEnvMap();
 });
 

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -1,0 +1,54 @@
+# Migration Python/Selenium vers Extension Chrome + Netlify
+
+## 1. Analyse du script source
+
+Le fichier `Python pour application.py.py` automatise deux sites via Selenium :
+
+- **ArcGIS WebAppViewer** : ouverture de la carte de la végétation, réglage d'une plage
+  de visibilité et d'une transparence.
+- **Géoportail** : recherche par coordonnées sur la carte des sols puis dézoom.
+
+Les coordonnées sont actuellement codées en dur. Les fonctions de lecture Excel
+et toute génération de fichiers sont ignorées dans la migration.
+
+## 2. Architecture cible
+
+### Extension Chrome
+
+- Manifest V3 avec `background.js`.
+- Permissions : `tabs`, `scripting`, accès aux domaines ArcGIS et Géoportail.
+- Un script `page-script.js` est injecté sur l'application Netlify pour écouter
+  `postMessage`.
+- Le service worker ouvre deux onglets configurés pour ArcGIS et Géoportail.
+- `arcgis.js` supprime automatiquement le splash‑screen.
+
+### Application Netlify
+
+- Nouveau fichier `extension-bridge.js` qui envoie
+  `postMessage({type:'open-maps', lat, lon})` lorsque l'utilisateur clique sur le
+  bouton « Cartes végétation/sols ».
+- Ajout d'un bouton dans `contexte.html`.
+
+### Protocole d'échange
+
+1. L'utilisateur choisit une localisation dans « Contexte éco ».
+2. La page déclenche l'événement `open-maps` avec les coordonnées.
+3. `page-script.js` relaie ce message au service worker.
+4. `background.js` ouvre les deux onglets et, pour ArcGIS, `arcgis.js` ferme le
+   splash‑screen.
+
+Objet transmis :
+
+```json
+{ "type": "open-maps", "lat": <float>, "lon": <float> }
+```
+
+## 3. Plan de migration
+
+1. Création de l'extension Chrome (manifest, scripts).
+2. Adaptation de l'app Netlify (bouton + `extension-bridge.js`).
+3. Tests de bout en bout sur les sites externes.
+4. Documentation utilisateur pour l'installation de l'extension.
+
+_Risques techniques :_ évolution de l'interface des sites tiers, restrictions de
+sécurité empêchant certains scripts, ou modification future des URL.

--- a/extension-bridge.js
+++ b/extension-bridge.js
@@ -1,0 +1,28 @@
+function openWithExtension(lat, lon) {
+  return new Promise((resolve) => {
+    const handler = (e) => {
+      if (e.data && e.data.type === 'open-maps-ack') {
+        window.removeEventListener('message', handler);
+        resolve(true);
+      }
+    };
+    window.addEventListener('message', handler, { once: true });
+    window.postMessage({ type: 'open-maps', lat, lon }, '*');
+    setTimeout(() => {
+      window.removeEventListener('message', handler);
+      resolve(false);
+    }, 500);
+  });
+}
+
+function launchExternalMaps() {
+  if (typeof selectedLat !== 'number' || typeof selectedLon !== 'number') {
+    showNotification('Choisissez d\'abord une localisation', 'error');
+    return;
+  }
+  openWithExtension(selectedLat, selectedLon).then((ok) => {
+    if (!ok) {
+      showNotification('Extension Chrome non d\u00e9tect\u00e9e', 'error');
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- document Selenium migration plan
- add a Chrome extension with service worker and content scripts
- expose an extension bridge in the web app
- integrate a launch button on the *Contexte éco* page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7f644d54832c89643a4e86e869d6