### PR TITLE
Fix JSON load issues by bumping SW cache

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,10 @@
  * Service-Worker – PlantID PWA
  * ================================================================ */
 
-const CACHE_NAME = "plantid-v24";
+// Augmenter le nom du cache force le service worker 
+// à recharger toutes les ressources, utile si un fichier
+// a été mis en cache de façon incomplète.
+const CACHE_NAME = "plantid-v25";
 
 const WASM_ASSETS = {
    "openjpeg.wasm": "./pdfjs/wasm/openjpeg.wasm.b64",


### PR DESCRIPTION
## Summary
- increment service worker cache version to force a refresh of cached data

This resolves issues with cached `ecology.json` being truncated and causing
`Unterminated string in JSON` errors.

## Testing
- `npm test` *(fails: jest not found)*
- `./scripts/setup-tests.sh` *(fails: 403 Forbidden while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d91514fb4832cb0b94db9435521b6