### PR TITLE
Improve map width in comparison view

### DIFF
--- a/style.css
+++ b/style.css
@@ -74,6 +74,25 @@ h1 {
     padding: 1rem;
 }
 
+/* Display comparison maps without padding or borders */
+#loc-content {
+    padding: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    margin-left: -1rem;
+    margin-right: -1rem;
+    width: calc(100% + 2rem);
+}
+
+@media (min-width: 600px) {
+    #loc-content {
+        margin-left: -2rem;
+        margin-right: -2rem;
+        width: calc(100% + 4rem);
+    }
+}
+
 .search-controls {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- allow comparison map to stretch across the full page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686de9525724832c939c8e3e96852bac