### PR TITLE
Add measure distance tool

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -48,6 +48,7 @@
                 <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
                 <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
                 <button id="toggle-labels-btn" class="action-button">Masquer les étiquettes</button>
+                <button id="measure-distance-btn" class="action-button">📏 Mesurer</button>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add a button to measure distance on the `biblio-patri` map
- implement measuring mode with mouse clicks or volume buttons

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686de966ee10832ca90a234b6ae7a452