### PR TITLE
Fix regional status matching in Biblio-Patri

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -262,18 +262,21 @@ let rulesByTaxonIndex = new Map();
         const lines = csvText.trim().split(/\r?\n/);
         const header = lines.shift().split(';').map(h => h.trim().replace(/"/g, ''));
         const indices = { adm: header.indexOf('LB_ADM_TR'), nom: header.indexOf('LB_NOM'), code: header.indexOf('CODE_STATUT'), type: header.indexOf('LB_TYPE_STATUT'), label: header.indexOf('LABEL_STATUT') };
-        
+
         const index = new Map();
         lines.forEach(line => {
             const cols = line.split(';');
             const rowData = {
-                adm: cols[indices.adm]?.trim().replace(/"/g, '') || '', nom: cols[indices.nom]?.trim().replace(/"/g, '') || '',
-                code: cols[indices.code]?.trim().replace(/"/g, '') || '', type: cols[indices.type]?.trim().replace(/"/g, '') || '',
+                adm: cols[indices.adm]?.trim().replace(/"/g, '') || '',
+                nom: cols[indices.nom]?.trim().replace(/"/g, '') || '',
+                code: cols[indices.code]?.trim().replace(/"/g, '') || '',
+                type: cols[indices.type]?.trim().replace(/"/g, '') || '',
                 label: cols[indices.label]?.trim().replace(/"/g, '') || ''
             };
             if (rowData.nom && rowData.type) {
-                if (!index.has(rowData.nom)) { index.set(rowData.nom, []); }
-                index.get(rowData.nom).push(rowData);
+                const key = norm(rowData.nom);
+                if (!index.has(key)) { index.set(key, []); }
+                index.get(key).push(rowData);
             }
         });
         return index;
@@ -710,7 +713,7 @@ const initializeSelectionMap = (coords) => {
             const relevantRules = new Map();
             const { departement, region } = (await (await fetch(`https://geo.api.gouv.fr/communes?lat=${params.latitude}&lon=${params.longitude}&fields=departement,region`)).json())[0];
             for (const speciesName of uniqueSpeciesNames) {
-                const rulesForThisTaxon = rulesByTaxonIndex.get(speciesName);
+                const rulesForThisTaxon = rulesByTaxonIndex.get(norm(speciesName));
                 if (rulesForThisTaxon) {
                     for (const row of rulesForThisTaxon) {
                         let ruleApplies = false;


### PR DESCRIPTION
## Summary
- normalise taxon names when building lookup index
- lookup patrimonial rules using normalized names

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686dee18b794832c801fcb27e24d666f