### PR TITLE
Handle normalized species names for regional protection rules

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -261,19 +261,28 @@ let rulesByTaxonIndex = new Map();
     const indexRulesFromCSV = (csvText) => {
         const lines = csvText.trim().split(/\r?\n/);
         const header = lines.shift().split(';').map(h => h.trim().replace(/"/g, ''));
-        const indices = { adm: header.indexOf('LB_ADM_TR'), nom: header.indexOf('LB_NOM'), code: header.indexOf('CODE_STATUT'), type: header.indexOf('LB_TYPE_STATUT'), label: header.indexOf('LABEL_STATUT') };
-        
+        const indices = {
+            adm: header.indexOf('LB_ADM_TR'),
+            nom: header.indexOf('LB_NOM'),
+            code: header.indexOf('CODE_STATUT'),
+            type: header.indexOf('LB_TYPE_STATUT'),
+            label: header.indexOf('LABEL_STATUT')
+        };
+
         const index = new Map();
         lines.forEach(line => {
             const cols = line.split(';');
             const rowData = {
-                adm: cols[indices.adm]?.trim().replace(/"/g, '') || '', nom: cols[indices.nom]?.trim().replace(/"/g, '') || '',
-                code: cols[indices.code]?.trim().replace(/"/g, '') || '', type: cols[indices.type]?.trim().replace(/"/g, '') || '',
+                adm: cols[indices.adm]?.trim().replace(/"/g, '') || '',
+                nom: cols[indices.nom]?.trim().replace(/"/g, '') || '',
+                code: cols[indices.code]?.trim().replace(/"/g, '') || '',
+                type: cols[indices.type]?.trim().replace(/"/g, '') || '',
                 label: cols[indices.label]?.trim().replace(/"/g, '') || ''
             };
             if (rowData.nom && rowData.type) {
-                if (!index.has(rowData.nom)) { index.set(rowData.nom, []); }
-                index.get(rowData.nom).push(rowData);
+                const key = norm(rowData.nom);
+                if (!index.has(key)) index.set(key, []);
+                index.get(key).push(rowData);
             }
         });
         return index;
@@ -710,7 +719,14 @@ const initializeSelectionMap = (coords) => {
             const relevantRules = new Map();
             const { departement, region } = (await (await fetch(`https://geo.api.gouv.fr/communes?lat=${params.latitude}&lon=${params.longitude}&fields=departement,region`)).json())[0];
             for (const speciesName of uniqueSpeciesNames) {
-                const rulesForThisTaxon = rulesByTaxonIndex.get(speciesName);
+                const normName = norm(speciesName);
+                let rulesForThisTaxon = rulesByTaxonIndex.get(normName);
+                if (!rulesForThisTaxon) {
+                    const simplified = speciesName.replace(/ subsp\..*/i, '').replace(/ var\..*/i, '').trim();
+                    if (simplified !== speciesName) {
+                        rulesForThisTaxon = rulesByTaxonIndex.get(norm(simplified));
+                    }
+                }
                 if (rulesForThisTaxon) {
                     for (const row of rulesForThisTaxon) {
                         let ruleApplies = false;


### PR DESCRIPTION
## Summary
- normalize species names when indexing BDCstatut rules
- match species names with normalization and fallback on simplified form

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dee212f64832c87c6e5bf9dbacef1