### PR TITLE
Ajout d'un outil de mesure avec dénivelé

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -48,6 +48,7 @@
                 <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
                 <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
                 <button id="toggle-labels-btn" class="action-button">🏷️ Masquer les étiquettes</button>
+                <button id="measure-distance-btn" class="action-button">📏 Mesurer</button>
             </div>
         </div>
 

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -78,6 +78,43 @@ document.addEventListener('DOMContentLoaded', async () => {
     let polygonPoints = [];
     let polygonPreview = null;
 
+    const ALTITUDES_URL = 'assets/altitudes_fr.json';
+    let altitudeDataPromise = null;
+    const loadAltitudeData = () => {
+        if (!altitudeDataPromise) {
+            altitudeDataPromise = fetch(ALTITUDES_URL)
+                .then(r => r.ok ? r.json() : {})
+                .catch(() => ({}));
+        }
+        return altitudeDataPromise;
+    };
+
+    const fetchAltitudeFromApi = async (lat, lon) => {
+        try {
+            const resp = await fetch(`https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m`);
+            if (!resp.ok) throw new Error('api');
+            const json = await resp.json();
+            if (typeof json.elevation === 'number') return json.elevation;
+        } catch (e) {
+            return null;
+        }
+        return null;
+    };
+
+    const fetchAltitude = async (lat, lon) => {
+        const apiAlt = await fetchAltitudeFromApi(lat, lon);
+        if (apiAlt !== null) return apiAlt;
+        const data = await loadAltitudeData();
+        const round = v => (Math.round(v * 2) / 2).toFixed(1);
+        const key = `${round(lat)},${round(lon)}`;
+        return data[key] ?? null;
+    };
+
+    let measuringDistance = false;
+    let measurePoints = [];
+    let measureLine = null;
+    let measureTooltip = null;
+
     const stopLocationTracking = () => {
         if (trackingWatchId !== null) {
             navigator.geolocation.clearWatch(trackingWatchId);
@@ -906,6 +943,87 @@ const initializeSelectionMap = (coords) => {
         window.addEventListener('keydown', onVolumeKey);
     };
 
+    const onMeasureVolume = async (e) => {
+        if (!measuringDistance) return;
+        if (e.key === 'AudioVolumeUp' || e.key === 'VolumeUp') {
+            e.preventDefault();
+            addMeasurePoint(map.getCenter());
+        } else if (e.key === 'AudioVolumeDown' || e.key === 'VolumeDown' || e.key === 'Backspace') {
+            e.preventDefault();
+            removeMeasurePoint();
+        }
+    };
+
+    const addMeasurePoint = async (latlng) => {
+        measurePoints.push(latlng);
+        if (measureLine) {
+            measureLine.setLatLngs(measurePoints);
+        } else {
+            measureLine = L.polyline(measurePoints, { color: '#c62828' }).addTo(map);
+        }
+        await updateMeasureTooltip(latlng);
+    };
+
+    const removeMeasurePoint = async () => {
+        measurePoints.pop();
+        if (measurePoints.length === 0) {
+            if (measureLine) { map.removeLayer(measureLine); measureLine = null; }
+            if (measureTooltip) { map.removeLayer(measureTooltip); measureTooltip = null; }
+            return;
+        }
+        if (measureLine) measureLine.setLatLngs(measurePoints);
+        await updateMeasureTooltip(measurePoints[measurePoints.length - 1]);
+    };
+
+    const updateMeasureTooltip = async (latlng) => {
+        let dist = 0;
+        for (let i = 1; i < measurePoints.length; i++) {
+            dist += measurePoints[i - 1].distanceTo(measurePoints[i]);
+        }
+        let text = dist < 1000 ? `${dist.toFixed(0)} m` : `${(dist/1000).toFixed(2)} km`;
+        if (measurePoints.length >= 2) {
+            const start = measurePoints[0];
+            const end = measurePoints[measurePoints.length - 1];
+            const [a1, a2] = await Promise.all([fetchAltitude(start.lat, start.lng), fetchAltitude(end.lat, end.lng)]);
+            if (a1 !== null && a2 !== null) {
+                const diff = Math.round(a2 - a1);
+                const sign = diff >= 0 ? '+' : '';
+                const dir = diff >= 0 ? 'd+' : 'd-';
+                text += ` (${sign}${diff} m ${dir})`;
+            }
+        }
+        if (!measureTooltip) {
+            measureTooltip = L.marker(latlng, { interactive:false, icon: L.divIcon({ className:'measure-tooltip', html:text }) }).addTo(map);
+        } else {
+            measureTooltip.setLatLng(latlng);
+            const el = measureTooltip.getElement();
+            if (el) el.innerHTML = text;
+        }
+    };
+
+    const toggleMeasureDistance = () => {
+        if (!map) return;
+        measuringDistance = !measuringDistance;
+        const btn = document.getElementById('measure-distance-btn');
+        if (measuringDistance) {
+            btn.textContent = 'Arrêter mesure';
+            measurePoints = [];
+            if (measureLine) { map.removeLayer(measureLine); measureLine = null; }
+            if (measureTooltip) { map.removeLayer(measureTooltip); measureTooltip = null; }
+            map.on('click', addMeasurePoint);
+            window.addEventListener('keydown', onMeasureVolume);
+            if (crosshair) crosshair.style.display = 'block';
+        } else {
+            btn.textContent = '📏 Mesurer';
+            map.off('click', addMeasurePoint);
+            window.removeEventListener('keydown', onMeasureVolume);
+            if (crosshair) crosshair.style.display = 'none';
+            if (measureLine) { map.removeLayer(measureLine); measureLine = null; }
+            if (measureTooltip) { map.removeLayer(measureTooltip); measureTooltip = null; }
+            measurePoints = [];
+        }
+    };
+
     let obsSearchCircle = null;
 
     const displayObservations = (occurrences) => {
@@ -1025,6 +1143,8 @@ const initializeSelectionMap = (coords) => {
     addressInput.addEventListener('keypress', (e) => e.key === 'Enter' && handleAddressSearch());
     downloadShapefileBtn.addEventListener('click', triggerShapefileDownload);
     toggleTrackingBtn.addEventListener('click', () => toggleLocationTracking(map, toggleTrackingBtn));
+    const measureBtn = document.getElementById('measure-distance-btn');
+    if (measureBtn) measureBtn.addEventListener('click', toggleMeasureDistance);
     if (toggleLabelsBtn) {
         toggleLabelsBtn.addEventListener('click', toggleAnalysisLabels);
     }

--- a/style.css
+++ b/style.css
@@ -258,6 +258,14 @@ th, td {
     color: var(--primary);
     text-shadow: 0 0 3px #fff;
 }
+
+.measure-tooltip {
+    background: var(--primary);
+    color: #fff;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+}
 th {
     font-weight: 600;
     background: #555555;


### PR DESCRIPTION
## Summary
- ajout d'un bouton `Mesurer` dans l'onglet Biblio Patri
- prise en charge du tracé de segments au clic ou avec les touches volume
- calcul de la distance et du dénivelé entre le premier et le dernier point
- ajout des styles pour l'infobulle de mesure

## Testing
- `./scripts/setup-tests.sh` *(échoue : accès réseau interdit)*
- `npm test` *(échoue : jest non trouvé)*

------
https://chatgpt.com/codex/tasks/task_e_686df0d00c04832cb6203e0c61bed7a6