### PR TITLE
Fix patrimonial status lookup

### DIFF
--- a/app.js
+++ b/app.js
@@ -1174,8 +1174,9 @@ async function loadBDCData() {
           label: c[idx.label] || ''
         };
         if (!row.nom) return;
-        if (!map.has(row.nom)) map.set(row.nom, []);
-        map.get(row.nom).push(row);
+        const key = norm(row.nom);
+        if (!map.has(key)) map.set(key, []);
+        map.get(key).push(row);
       });
       bdcRulesByTaxon = map;
     });
@@ -1222,7 +1223,7 @@ async function runStatusAnalysis() {
     const name = latinCell ? (latinCell.dataset.latin || latinCell.textContent.split('\n')[0]).trim() : '';
     if (!name) return;
     uniqueSpeciesNames.push(name);
-    const rulesForThisTaxon = bdcRulesByTaxon.get(name) || [];
+    const rulesForThisTaxon = bdcRulesByTaxon.get(norm(name)) || [];
     rulesForThisTaxon.forEach(r => {
       let ruleApplies = false;
       const type = r.type.toLowerCase();

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -267,13 +267,16 @@ let rulesByTaxonIndex = new Map();
         lines.forEach(line => {
             const cols = line.split(';');
             const rowData = {
-                adm: cols[indices.adm]?.trim().replace(/"/g, '') || '', nom: cols[indices.nom]?.trim().replace(/"/g, '') || '',
-                code: cols[indices.code]?.trim().replace(/"/g, '') || '', type: cols[indices.type]?.trim().replace(/"/g, '') || '',
+                adm: cols[indices.adm]?.trim().replace(/"/g, '') || '',
+                nom: cols[indices.nom]?.trim().replace(/"/g, '') || '',
+                code: cols[indices.code]?.trim().replace(/"/g, '') || '',
+                type: cols[indices.type]?.trim().replace(/"/g, '') || '',
                 label: cols[indices.label]?.trim().replace(/"/g, '') || ''
             };
             if (rowData.nom && rowData.type) {
-                if (!index.has(rowData.nom)) { index.set(rowData.nom, []); }
-                index.get(rowData.nom).push(rowData);
+                const key = norm(rowData.nom);
+                if (!index.has(key)) { index.set(key, []); }
+                index.get(key).push(rowData);
             }
         });
         return index;
@@ -710,7 +713,7 @@ const initializeSelectionMap = (coords) => {
             const relevantRules = new Map();
             const { departement, region } = (await (await fetch(`https://geo.api.gouv.fr/communes?lat=${params.latitude}&lon=${params.longitude}&fields=departement,region`)).json())[0];
             for (const speciesName of uniqueSpeciesNames) {
-                const rulesForThisTaxon = rulesByTaxonIndex.get(speciesName);
+                const rulesForThisTaxon = rulesByTaxonIndex.get(norm(speciesName));
                 if (rulesForThisTaxon) {
                     for (const row of rulesForThisTaxon) {
                         let ruleApplies = false;


### PR DESCRIPTION
## Summary
- normalize species names when indexing and retrieving BDCstatut rules
- lookup rules using normalized names for map analysis

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686df282f3a4832c82fa1df2fa90fff5