### PR TITLE
Add distance and elevation measurement to Patri map

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -23,6 +23,13 @@
     <style>
       .logo-icon { width: 24px; height: auto; }
       .small-logo { height: 24px; width: auto; }
+      .measure-tooltip {
+        background: var(--primary);
+        color: #fff;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 0.8rem;
+      }
     </style>
 </head>
 <body>
@@ -48,6 +55,7 @@
                 <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
                 <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
                 <button id="toggle-labels-btn" class="action-button">🏷️ Masquer les étiquettes</button>
+                <button id="measure-distance-btn" class="action-button">📏 Mesurer</button>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add measurement button to Biblio Patri map page
- implement measurement mode with distance and elevation gain
- support right click or long press to add points

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e06b71d74832caa3d2cdb9c17d066