### PR TITLE
Remove borders around embedded comparison map

### DIFF
--- a/carte_interactive/map_view.html
+++ b/carte_interactive/map_view.html
@@ -32,5 +32,13 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     
     <script src="script.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const params = new URLSearchParams(window.location.search);
+        if (params.has('embed')) {
+          document.body.classList.add('embed');
+        }
+      });
+    </script>
 </body>
 </html>

--- a/carte_interactive/style.css
+++ b/carte_interactive/style.css
@@ -167,6 +167,13 @@ main {
     z-index: 1000;
 }
 
+body.embed #map {
+    margin: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+}
+
 /* Style pour les icônes SVG personnalisées */
 .custom-div-icon {
     background: transparent;

--- a/compare-page.js
+++ b/compare-page.js
@@ -76,7 +76,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const speciesParam = params.get('species');
     if (speciesParam) {
         const frame = document.getElementById('map-frame');
-        frame.src = 'carte_interactive/map_view.html?species=' + encodeURIComponent(speciesParam);
+        frame.src = 'carte_interactive/map_view.html?species=' + encodeURIComponent(speciesParam) + '&embed=1';
     }
     showTab('loc');
 });


### PR DESCRIPTION
## Summary
- remove default borders when the GBIF occurrence map is embedded
- pass `embed=1` flag to the map iframe

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e16c4289c832ca1cd60e39ec07b05