### PR TITLE
Fix regional rule lookup via normalized names

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -261,19 +261,28 @@ let rulesByTaxonIndex = new Map();
     const indexRulesFromCSV = (csvText) => {
         const lines = csvText.trim().split(/\r?\n/);
         const header = lines.shift().split(';').map(h => h.trim().replace(/"/g, ''));
-        const indices = { adm: header.indexOf('LB_ADM_TR'), nom: header.indexOf('LB_NOM'), code: header.indexOf('CODE_STATUT'), type: header.indexOf('LB_TYPE_STATUT'), label: header.indexOf('LABEL_STATUT') };
-        
+        const indices = {
+            adm: header.indexOf('LB_ADM_TR'),
+            nom: header.indexOf('LB_NOM'),
+            code: header.indexOf('CODE_STATUT'),
+            type: header.indexOf('LB_TYPE_STATUT'),
+            label: header.indexOf('LABEL_STATUT')
+        };
+
         const index = new Map();
         lines.forEach(line => {
             const cols = line.split(';');
             const rowData = {
-                adm: cols[indices.adm]?.trim().replace(/"/g, '') || '', nom: cols[indices.nom]?.trim().replace(/"/g, '') || '',
-                code: cols[indices.code]?.trim().replace(/"/g, '') || '', type: cols[indices.type]?.trim().replace(/"/g, '') || '',
+                adm: cols[indices.adm]?.trim().replace(/"/g, '') || '',
+                nom: cols[indices.nom]?.trim().replace(/"/g, '') || '',
+                code: cols[indices.code]?.trim().replace(/"/g, '') || '',
+                type: cols[indices.type]?.trim().replace(/"/g, '') || '',
                 label: cols[indices.label]?.trim().replace(/"/g, '') || ''
             };
             if (rowData.nom && rowData.type) {
-                if (!index.has(rowData.nom)) { index.set(rowData.nom, []); }
-                index.get(rowData.nom).push(rowData);
+                const key = norm(rowData.nom);
+                if (!index.has(key)) index.set(key, []);
+                index.get(key).push(rowData);
             }
         });
         return index;
@@ -710,7 +719,7 @@ const initializeSelectionMap = (coords) => {
             const relevantRules = new Map();
             const { departement, region } = (await (await fetch(`https://geo.api.gouv.fr/communes?lat=${params.latitude}&lon=${params.longitude}&fields=departement,region`)).json())[0];
             for (const speciesName of uniqueSpeciesNames) {
-                const rulesForThisTaxon = rulesByTaxonIndex.get(speciesName);
+                const rulesForThisTaxon = rulesByTaxonIndex.get(norm(speciesName));
                 if (rulesForThisTaxon) {
                     for (const row of rulesForThisTaxon) {
                         let ruleApplies = false;


### PR DESCRIPTION
## Summary
- normalize species names when indexing `BDCstatut.csv`
- use normalized names when searching patrimonial rules

## Testing
- `./scripts/setup-tests.sh` *(fails: 403 Forbidden npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_686df290335c832ca7e8df0895385269