### PR TITLE
Add elevation profile to measure tool

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -24,11 +24,22 @@
       .logo-icon { width: 24px; height: auto; }
       .small-logo { height: 24px; width: auto; }
       .measure-tooltip {
-        background: var(--primary);
-        color: #fff;
+        background: #fff;
+        color: #000;
         padding: 2px 6px;
         border-radius: 4px;
+        border: 1px solid #000;
         font-size: 0.8rem;
+      }
+
+      .measure-profile {
+        background: #fff;
+        border: 1px solid #000;
+        width: 100%;
+        max-width: 400px;
+        height: 150px;
+        display: none;
+        margin: 0.5rem auto;
       }
     </style>
 </head>
@@ -64,6 +75,7 @@
         <div id="map">
             <div id="crosshair" style="display:none;"></div>
         </div>
+        <canvas id="measure-profile" class="measure-profile"></canvas>
 
         <div id="download-container" style="text-align:center; display:none; margin-bottom:1rem;">
             <button id="download-shapefile-btn" class="action-button">⬇️ Shapefile</button>


### PR DESCRIPTION
## Summary
- restyle measurement tooltip for clarity and add canvas container for profile
- show cumulative positive and negative elevation gain
- draw a dynamic elevation profile along the measured segment
- hide the profile when measurement mode ends

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e9795952c832c91ba3a71410bdcf0