### PR TITLE
Add measurement info display

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -31,17 +31,27 @@
         border-radius: 4px;
         font-size: 0.8rem;
       }
-      #profile-canvas {
+      #profile-container {
         position: absolute;
         bottom: 10px;
         left: 10px;
         width: 200px;
-        height: 100px;
         background: rgba(255,255,255,0.9);
         border: 1px solid #000;
         border-radius: 4px;
+        padding: 4px;
+        font-size: 0.8rem;
         display: none;
         z-index: 1000;
+      }
+      #profile-canvas {
+        width: 100%;
+        height: 100px;
+        display: block;
+      }
+      #measure-info {
+        margin-top: 4px;
+        white-space: pre-line;
       }
     </style>
 </head>
@@ -76,7 +86,10 @@
 
         <div id="map">
             <div id="crosshair" style="display:none;"></div>
-            <canvas id="profile-canvas" width="200" height="100"></canvas>
+            <div id="profile-container">
+                <canvas id="profile-canvas" width="200" height="100"></canvas>
+                <div id="measure-info"></div>
+            </div>
         </div>
 
         <div id="download-container" style="text-align:center; display:none; margin-bottom:1rem;">

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -27,6 +27,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     const toggleLabelsBtn = document.getElementById('toggle-labels-btn');
     const measureDistanceBtn = document.getElementById('measure-distance-btn');
     const profileCanvas = document.getElementById('profile-canvas');
+    const profileContainer = document.getElementById('profile-container');
+    const measureInfo = document.getElementById('measure-info');
     const downloadShapefileBtn = document.getElementById('download-shapefile-btn');
     const downloadContainer = document.getElementById('download-container');
     const navContainer = document.getElementById('section-nav');
@@ -175,9 +177,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     };
 
     const drawElevationProfile = () => {
-        if (!profileCanvas) return;
+        if (!profileCanvas || !profileContainer) return;
         if (measurePoints.length < 2) {
-            profileCanvas.style.display = 'none';
+            profileContainer.style.display = 'none';
             return;
         }
         const ctx = profileCanvas.getContext('2d');
@@ -208,7 +210,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         ctx.strokeStyle = '#c62828';
         ctx.lineWidth = 2;
         ctx.stroke();
-        profileCanvas.style.display = 'block';
+        profileContainer.style.display = 'block';
     };
 
     const updateMeasureDisplay = async (latlng) => {
@@ -229,6 +231,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (elevPos > 0) elevText += ` +${Math.round(elevPos)} m`;
         if (elevNeg > 0) elevText += ` -${Math.round(elevNeg)} m`;
         const text = elevText ? `${textDist} (${elevText.trim()})` : textDist;
+        if (measureInfo) {
+            const info = `Distance : ${textDist}\n\nD+ total : ${Math.round(elevPos)} m\n\nD- total : ${Math.round(elevNeg)} m`;
+            measureInfo.innerText = info;
+        }
         if (!measureTooltip) {
             measureTooltip = L.marker(latlng, {
                 interactive: false,
@@ -265,14 +271,16 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (profileCanvas) {
                 const ctx = profileCanvas.getContext('2d');
                 ctx && ctx.clearRect(0, 0, profileCanvas.width, profileCanvas.height);
-                profileCanvas.style.display = 'none';
             }
+            if (profileContainer) profileContainer.style.display = 'none';
+            if (measureInfo) measureInfo.innerText = '';
             measureDistanceBtn.textContent = '🛑 Fin mesure';
         } else {
             if (measureLine) { map.removeLayer(measureLine); measureLine = null; }
             if (measureTooltip) { map.removeLayer(measureTooltip); measureTooltip = null; }
             measurePoints = [];
-            if (profileCanvas) profileCanvas.style.display = 'none';
+            if (profileContainer) profileContainer.style.display = 'none';
+            if (measureInfo) measureInfo.innerText = '';
             measureDistanceBtn.textContent = '📏 Mesurer';
         }
     };


### PR DESCRIPTION
## Summary
- show altitude profile and measurement info in a single container
- compute distance and total ascent/descent in `biblio-patri.js`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686f4b810cbc832ca493869085357286