### PR TITLE
Affichage détails mesure dans le profil altitude

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -31,17 +31,28 @@
         border-radius: 4px;
         font-size: 0.8rem;
       }
-      #profile-canvas {
+      #profile-container {
         position: absolute;
         bottom: 10px;
         left: 10px;
         width: 200px;
-        height: 100px;
         background: rgba(255,255,255,0.9);
         border: 1px solid #000;
         border-radius: 4px;
+        padding: 4px;
         display: none;
         z-index: 1000;
+      }
+      #profile-canvas {
+        width: 100%;
+        height: 100px;
+        display: block;
+      }
+      #profile-info {
+        font-size: 0.8rem;
+        line-height: 1.2;
+        margin-top: 4px;
+        white-space: pre-line;
       }
     </style>
 </head>
@@ -76,7 +87,10 @@
 
         <div id="map">
             <div id="crosshair" style="display:none;"></div>
-            <canvas id="profile-canvas" width="200" height="100"></canvas>
+            <div id="profile-container">
+                <canvas id="profile-canvas" width="200" height="100"></canvas>
+                <div id="profile-info"></div>
+            </div>
         </div>
 
         <div id="download-container" style="text-align:center; display:none; margin-bottom:1rem;">

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -26,7 +26,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     const toggleTrackingBtn = document.getElementById('toggle-tracking-btn');
     const toggleLabelsBtn = document.getElementById('toggle-labels-btn');
     const measureDistanceBtn = document.getElementById('measure-distance-btn');
+    const profileContainer = document.getElementById('profile-container');
     const profileCanvas = document.getElementById('profile-canvas');
+    const profileInfo = document.getElementById('profile-info');
     const downloadShapefileBtn = document.getElementById('download-shapefile-btn');
     const downloadContainer = document.getElementById('download-container');
     const navContainer = document.getElementById('section-nav');
@@ -175,9 +177,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     };
 
     const drawElevationProfile = () => {
-        if (!profileCanvas) return;
+        if (!profileCanvas || !profileContainer) return;
         if (measurePoints.length < 2) {
-            profileCanvas.style.display = 'none';
+            profileContainer.style.display = 'none';
             return;
         }
         const ctx = profileCanvas.getContext('2d');
@@ -208,7 +210,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         ctx.strokeStyle = '#c62828';
         ctx.lineWidth = 2;
         ctx.stroke();
-        profileCanvas.style.display = 'block';
+        profileContainer.style.display = 'block';
     };
 
     const updateMeasureDisplay = async (latlng) => {
@@ -225,10 +227,17 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
         }
         const textDist = dist < 1000 ? `${dist.toFixed(0)} m` : `${(dist/1000).toFixed(2)} km`;
-        let elevText = '';
-        if (elevPos > 0) elevText += ` +${Math.round(elevPos)} m`;
-        if (elevNeg > 0) elevText += ` -${Math.round(elevNeg)} m`;
-        const text = elevText ? `${textDist} (${elevText.trim()})` : textDist;
+        const dPlus = Math.round(elevPos);
+        const dMinus = Math.round(elevNeg);
+        if (profileInfo) {
+            profileInfo.innerHTML =
+                `Distance : ${textDist}<br>D+ total : ${dPlus} m<br>D- total : ${dMinus} m`;
+        }
+        const elevTextParts = [];
+        if (dPlus > 0) elevTextParts.push(`+${dPlus} m`);
+        if (dMinus > 0) elevTextParts.push(`-${dMinus} m`);
+        const elevText = elevTextParts.join(' ');
+        const text = elevText ? `${textDist} (${elevText})` : textDist;
         if (!measureTooltip) {
             measureTooltip = L.marker(latlng, {
                 interactive: false,
@@ -265,14 +274,16 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (profileCanvas) {
                 const ctx = profileCanvas.getContext('2d');
                 ctx && ctx.clearRect(0, 0, profileCanvas.width, profileCanvas.height);
-                profileCanvas.style.display = 'none';
+            }
+            if (profileContainer) {
+                profileContainer.style.display = 'none';
             }
             measureDistanceBtn.textContent = '🛑 Fin mesure';
         } else {
             if (measureLine) { map.removeLayer(measureLine); measureLine = null; }
             if (measureTooltip) { map.removeLayer(measureTooltip); measureTooltip = null; }
             measurePoints = [];
-            if (profileCanvas) profileCanvas.style.display = 'none';
+            if (profileContainer) profileContainer.style.display = 'none';
             measureDistanceBtn.textContent = '📏 Mesurer';
         }
     };


### PR DESCRIPTION
## Summary
- ajoute un conteneur `#profile-container` intégrant le canvas du profil d'altitude et un espace texte
- affiche la distance et le dénivelé cumulé positif/négatif sous forme de trois lignes dans cet encart
- met à jour le code JS pour renseigner les valeurs et gérer l'affichage

## Testing
- `npm test` *(échoue : jest non trouvé)*

------
https://chatgpt.com/codex/tasks/task_e_686f4b83d11c832c962d229913891ebf