### PR TITLE
Limite l'échantillonnage du profil topo à 100 m

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -124,7 +124,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         return data[key] ?? null;
     };
 
-    const sampleSegment = async (p1, p2, step = 20) => {
+    // Échantillonnage d'un segment pour le profil altimétrique
+    // Un point est pris environ toutes les 100 m pour limiter le nombre de
+    // requêtes d'altitude et l'affichage du profil.
+    const sampleSegment = async (p1, p2, step = 100) => {
         const dist = p1.latlng.distanceTo(p2.latlng);
         const samples = [];
         const n = Math.max(1, Math.round(dist / step));


### PR DESCRIPTION
## Summary
- échantillonne les segments de mesure tous les 100 m au lieu de 20 dans biblio-patri.js

## Testing
- `npm test` *(fails: jest not found)*
- `./scripts/setup-tests.sh` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686f64dfcc10832c864cde2bdc97c47b