### PR TITLE
Set OpenTopoMap as default basemap

### DIFF
--- a/contexte.js
+++ b/contexte.js
@@ -48,14 +48,11 @@ function initializeEnvMap() {
         maxZoom: 17,
         crossOrigin: true
     }).addTo(envMap);
+    // Keep OpenTopoMap as the default background. If the tiles fail to load,
+    // we simply log the error instead of switching to OpenStreetMap so that
+    // the user does not see an unexpected change of basemap.
     topoLayer.on('tileerror', () => {
-        if (envMap.hasLayer(topoLayer)) {
-            envMap.removeLayer(topoLayer);
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                attribution: '© OpenStreetMap contributors',
-                maxZoom: 19
-            }).addTo(envMap);
-        }
+        console.warn('OpenTopoMap tiles could not be loaded.');
     });
     enableChoicePopup(envMap);
 }
@@ -426,14 +423,10 @@ async function displayInteractiveEnvMap() {
             maxZoom: 17,
             crossOrigin: true
         }).addTo(envMap);
+        // Keep OpenTopoMap as the preferred basemap. On tile errors we just log
+        // the issue instead of switching to OpenStreetMap.
         topoLayer.on('tileerror', () => {
-            if (envMap.hasLayer(topoLayer)) {
-                envMap.removeLayer(topoLayer);
-                L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                    attribution: '© OpenStreetMap contributors',
-                    maxZoom: 19
-                }).addTo(envMap);
-            }
+            console.warn('OpenTopoMap tiles could not be loaded.');
         });
     } else {
         envMap.setView([selectedLat, selectedLon], 11);


### PR DESCRIPTION
## Summary
- keep OpenTopoMap instead of switching to OSM on tile errors in the eco context map

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686f65d5c048832c85660807f60f009f