### PR TITLE
Limit x-axis ticks for elevation profile

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -232,7 +232,17 @@ document.addEventListener('DOMContentLoaded', async () => {
             return 5 * pow;
         };
 
-        const distSpacing = niceStep(totalDist / 5);
+        const maxDistTicks = 5;
+        let distSpacing = niceStep(totalDist / 4);
+        let distTicks = Math.floor(totalDist / distSpacing) + 1;
+        if (distTicks > maxDistTicks) {
+            distSpacing = niceStep(totalDist / maxDistTicks);
+            distTicks = Math.floor(totalDist / distSpacing) + 1;
+            while (distTicks > maxDistTicks) {
+                distSpacing *= 2;
+                distTicks = Math.floor(totalDist / distSpacing) + 1;
+            }
+        }
         const altRange = maxAlt - minAlt;
         let altSpacing = niceStep(altRange / 4);
         let altTicks = Math.floor(altRange / altSpacing) + 1;


### PR DESCRIPTION
## Summary
- limit the number of tick labels for the distance axis on the elevation profile to a maximum of five

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68709aa5ce80832c82ae234e48bec8d6