### PR TITLE
Limit tick labels on distance axis

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -232,7 +232,16 @@ document.addEventListener('DOMContentLoaded', async () => {
             return 5 * pow;
         };
 
-        const distSpacing = niceStep(totalDist / 5);
+        let distSpacing = niceStep(totalDist / 4);
+        let distTicks = Math.floor(totalDist / distSpacing) + 1;
+        if (distTicks > 5) {
+            distSpacing = niceStep(totalDist / 5);
+            distTicks = Math.floor(totalDist / distSpacing) + 1;
+            while (distTicks > 5) {
+                distSpacing *= 2;
+                distTicks = Math.floor(totalDist / distSpacing) + 1;
+            }
+        }
         const altRange = maxAlt - minAlt;
         let altSpacing = niceStep(altRange / 4);
         let altTicks = Math.floor(altRange / altSpacing) + 1;


### PR DESCRIPTION
## Summary
- constrain the number of tick labels on the elevation profile distance axis

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68709aa707ac832cb97ee4e1e6517780