### PR TITLE
Limite les valeurs de distance sur le profil

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -232,7 +232,17 @@ document.addEventListener('DOMContentLoaded', async () => {
             return 5 * pow;
         };
 
-        const distSpacing = niceStep(totalDist / 5);
+        const maxDistTicks = 5;
+        let distSpacing = niceStep(totalDist / (maxDistTicks - 1));
+        let distTicks = Math.floor(totalDist / distSpacing) + 1;
+        if (distTicks > maxDistTicks) {
+            distSpacing = niceStep(totalDist / maxDistTicks);
+            distTicks = Math.floor(totalDist / distSpacing) + 1;
+            while (distTicks > maxDistTicks) {
+                distSpacing *= 2;
+                distTicks = Math.floor(totalDist / distSpacing) + 1;
+            }
+        }
         const altRange = maxAlt - minAlt;
         let altSpacing = niceStep(altRange / 4);
         let altTicks = Math.floor(altRange / altSpacing) + 1;


### PR DESCRIPTION
## Résumé
- ajuste le calcul de l'espacement des distances dans `biblio-patri.js`
- limite les graduations visibles sur l'axe des abscisses à 5 maximum

## Tests
- `npm test` *(échoue : jest non trouvé)*

------
https://chatgpt.com/codex/tasks/task_e_68709aa890fc832c917e68ff78c4973d