### PR TITLE
Implement exhaustive GBIF search

### DIFF
--- a/__tests__/gbif-fullsearch.test.js
+++ b/__tests__/gbif-fullsearch.test.js
@@ -1,0 +1,24 @@
+const { loadGbifFullHandler } = require('../test-utils');
+
+function createMockFetch(responses) {
+  let call = 0;
+  return jest.fn().mockImplementation(() => {
+    const body = responses[call++] || responses[responses.length - 1];
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+  });
+}
+
+describe('gbif-fullsearch handler', () => {
+  test('aggregates all pages', async () => {
+    const count = 3;
+    const resp1 = { count, results: [{ id: 1 }] };
+    const resp2 = { results: [{ id: 2 }] };
+    const resp3 = { results: [{ id: 3 }] };
+    const fetchMock = createMockFetch([resp1, resp2, resp3]);
+    const handler = loadGbifFullHandler(fetchMock);
+    const res = await handler({ queryStringParameters: { geometry: 'POLYGON' } });
+    const body = JSON.parse(res.body);
+    expect(body.results.length).toBe(3);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/netlify.toml
+++ b/netlify.toml
@@ -38,3 +38,8 @@
   to = "/.netlify/functions/gbif-proxy"
   status = 200
   force = true
+[[redirects]]
+  from = "/api/gbif-full"
+  to = "/.netlify/functions/gbif-fullsearch"
+  status = 200
+  force = true

--- a/netlify/functions/gbif-fullsearch.js
+++ b/netlify/functions/gbif-fullsearch.js
@@ -1,0 +1,56 @@
+const fetch = require('./utils/fetch');
+const fs = require('fs').promises;
+const os = require('os');
+const path = require('path');
+
+exports.handler = async function(event) {
+  const params = event.queryStringParameters || {};
+  const geometry = params.geometry;
+  if (!geometry) {
+    return { statusCode: 400, body: 'Missing geometry parameter' };
+  }
+
+  const limit = 300;
+  const baseUrl = 'https://api.gbif.org/v1/occurrence/search';
+  try {
+    const metaResp = await fetch(`${baseUrl}?limit=1&geometry=${encodeURIComponent(geometry)}&kingdomKey=6`);
+    if (!metaResp.ok) throw new Error('Failed to fetch count');
+    const meta = await metaResp.json();
+    const totalPages = Math.ceil(meta.count / limit);
+    const batchSize = 20;
+    const tempFiles = [];
+
+    for (let start = 0; start < totalPages; start += batchSize) {
+      const end = Math.min(totalPages, start + batchSize);
+      let batchResults = [];
+      for (let page = start; page < end; page++) {
+        const offset = page * limit;
+        const url = `${baseUrl}?limit=${limit}&offset=${offset}&geometry=${encodeURIComponent(geometry)}&kingdomKey=6`;
+        const resp = await fetch(url);
+        if (!resp.ok) throw new Error('Failed to fetch page');
+        const data = await resp.json();
+        if (Array.isArray(data.results)) batchResults.push(...data.results);
+      }
+      const file = path.join(os.tmpdir(), `gbif_batch_${tempFiles.length + 1}.json`);
+      await fs.writeFile(file, JSON.stringify(batchResults), 'utf8');
+      tempFiles.push(file);
+      batchResults = null;
+    }
+
+    let allResults = [];
+    for (const f of tempFiles) {
+      const content = await fs.readFile(f, 'utf8');
+      allResults.push(...JSON.parse(content));
+      await fs.unlink(f).catch(() => {});
+    }
+
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ results: allResults })
+    };
+  } catch (err) {
+    console.error('gbif-fullsearch error:', err);
+    return { statusCode: 500, body: 'Server error' };
+  }
+};

--- a/test-utils.js
+++ b/test-utils.js
@@ -70,6 +70,16 @@ function loadGbifHandler(mockFetch) {
   vm.runInContext(patched, context);
   return context.exports.handler;
 }
+function loadGbifFullHandler(mockFetch) {
+  const code = fs.readFileSync("netlify/functions/gbif-fullsearch.js", "utf-8");
+  const patched = code.replace(/const fetch = require(./utils/fetch);/, "const fetch = (...args) => global.__fetch(...args);");
+  const context = { require, console, exports: {}, __fetch: mockFetch, fs, os: { tmpdir: () => "/tmp" }, path: require("path") };
+  context.global = context;
+  vm.createContext(context);
+  vm.runInContext(patched, context);
+  return context.exports.handler;
+}
+
 
 function mockFetch(html) {
   return jest.fn().mockResolvedValue({
@@ -103,4 +113,4 @@ function loadAnalyzeHandler(mockFetch, env = {}) {
   return context.exports.handler;
 }
 
-module.exports = { loadApp, loadHandler, loadAuraHandler, loadGbifHandler, loadApiProxyHandler, loadAnalyzeHandler, mockFetch };
+module.exports = { loadApp, loadHandler, loadAuraHandler, loadGbifHandler, loadGbifFullHandler, loadApiProxyHandler, loadAnalyzeHandler, mockFetch };


### PR DESCRIPTION
## Summary
- add gbif-fullsearch Netlify function to load GBIF data in batches on the server
- wire new 'Flore patri approfondie' button to run deep search
- call the new function in `runAnalysis` when deep search is requested
- expose helper for the function in tests and test gbif-fullsearch handler
- route `/api/gbif-full` to the new function

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68709f14ed54832c88bdbba66184be21