### PR TITLE
Update measure display

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -23,14 +23,6 @@
     <style>
       .logo-icon { width: 24px; height: auto; }
       .small-logo { height: 24px; width: auto; }
-      .measure-tooltip {
-        background: #ffffff;
-        color: #000000;
-        padding: 2px 6px;
-        border: 1px solid #000000;
-        border-radius: 4px;
-        font-size: 0.8rem;
-      }
       #profile-container {
         position: absolute;
         bottom: 10px;

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -87,7 +87,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     let measurePoints = [];
     let profileSamples = [];
     let measureLine = null;
-    let measureTooltip = null;
 
     const ALTITUDES_URL = 'assets/altitudes_fr.json';
     let altitudeDataPromise = null;
@@ -319,21 +318,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             profileInfo.innerHTML =
                 `Distance : ${textDist}<br>D+ total : ${dPlus} m<br>D- total : ${dMinus} m`;
         }
-        const elevTextParts = [];
-        if (dPlus > 0) elevTextParts.push(`+${dPlus} m`);
-        if (dMinus > 0) elevTextParts.push(`-${dMinus} m`);
-        const elevText = elevTextParts.join(' ');
-        const text = elevText ? `${textDist} (${elevText})` : textDist;
-        if (!measureTooltip) {
-            measureTooltip = L.marker(latlng, {
-                interactive: false,
-                icon: L.divIcon({ className: 'measure-tooltip', html: text })
-            }).addTo(map);
-        } else {
-            measureTooltip.setLatLng(latlng);
-            const el = measureTooltip.getElement();
-            if (el) el.innerHTML = text;
-        }
+        // No tooltip on the map: information is shown beside the profile
         drawElevationProfile();
     };
 
@@ -365,7 +350,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             measurePoints = [];
             profileSamples = [];
             if (measureLine) { map.removeLayer(measureLine); measureLine = null; }
-            if (measureTooltip) { map.removeLayer(measureTooltip); measureTooltip = null; }
             if (profileCanvas) {
                 const ctx = profileCanvas.getContext('2d');
                 ctx && ctx.clearRect(0, 0, profileCanvas.width, profileCanvas.height);
@@ -376,7 +360,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             measureDistanceBtn.textContent = '🛑 Fin mesure';
         } else {
             if (measureLine) { map.removeLayer(measureLine); measureLine = null; }
-            if (measureTooltip) { map.removeLayer(measureTooltip); measureTooltip = null; }
             measurePoints = [];
             profileSamples = [];
             if (profileContainer) profileContainer.style.display = 'none';


### PR DESCRIPTION
## Summary
- hide distance and elevation tooltip on the map
- keep measurement information next to the elevation profile

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_687110ff8fe4832c862ae0ba3858f7ec