### PR TITLE
Shorten Biblio progress bar

### DIFF
--- a/style.css
+++ b/style.css
@@ -163,6 +163,9 @@ h1 {
     margin: 0.5rem 0;
     font-size: 1rem;
     min-height: 24px;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
 }
 
 /* Icons and text horizontally aligned for status messages */
@@ -173,12 +176,12 @@ h1 {
 }
 
 #progress-container {
-    width: 100%;
+    width: 60px;
     height: 6px;
     background-color: var(--border);
     border-radius: 3px;
     overflow: hidden;
-    margin-bottom: 0.25rem;
+    margin-bottom: 0;
 }
 
 #progress-bar {


### PR DESCRIPTION
## Summary
- keep status section inline and centered
- shrink progress bar width so it doesn't span the whole page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687112f1f420832c8c9a2fef1e7ce7c1