### PR TITLE
Move measure results next to profile

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -35,24 +35,30 @@
         position: absolute;
         bottom: 10px;
         left: 10px;
-        width: 300px;
         background: rgba(255,255,255,0.9);
         border: 1px solid #000;
         border-radius: 4px;
         padding: 4px;
         display: none;
         z-index: 1000;
+        display: flex;
+        align-items: flex-start;
       }
       #profile-canvas {
-        width: 100%;
+        width: 300px;
         height: 100px;
         display: block;
       }
       #profile-info {
         font-size: 0.8rem;
         line-height: 1.2;
-        margin-top: 4px;
+        margin-left: 6px;
         white-space: nowrap;
+        background: #ffffff;
+        color: #000000;
+        padding: 2px 6px;
+        border: 1px solid #000000;
+        border-radius: 4px;
       }
     </style>
 </head>

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -321,21 +321,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             profileInfo.innerHTML =
                 `Distance : ${textDist}<br>D+ total : ${dPlus} m<br>D- total : ${dMinus} m`;
         }
-        const elevTextParts = [];
-        if (dPlus > 0) elevTextParts.push(`+${dPlus} m`);
-        if (dMinus > 0) elevTextParts.push(`-${dMinus} m`);
-        const elevText = elevTextParts.join(' ');
-        const text = elevText ? `${textDist} (${elevText})` : textDist;
-        if (!measureTooltip) {
-            measureTooltip = L.marker(latlng, {
-                interactive: false,
-                icon: L.divIcon({ className: 'measure-tooltip', html: text })
-            }).addTo(map);
-        } else {
-            measureTooltip.setLatLng(latlng);
-            const el = measureTooltip.getElement();
-            if (el) el.innerHTML = text;
-        }
         drawElevationProfile();
     };
 


### PR DESCRIPTION
## Summary
- show distance and elevation info in a box next to the elevation profile
- remove map tooltip for measurement results

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_687117713c4c832c8101d396faf099f2