### PR TITLE
Fix overflowing patrimonial popups

### DIFF
--- a/style.css
+++ b/style.css
@@ -413,3 +413,9 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
     height: 2px;
     background: var(--primary);
 }
+
+/* Popups patrimoniales scrollables */
+.custom-popup {
+    max-height: 200px;
+    overflow-y: auto;
+}


### PR DESCRIPTION
## Summary
- add CSS class to limit patrimonial popup height and enable scrolling

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874c4218234832c9d60f88f43bbf9bb