### PR TITLE
Switch polygon drawing to click-based interactions

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -83,6 +83,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     let polygonDrawing = false;
     let polygonPoints = [];
     let polygonPreview = null;
+    let polygonMarkers = [];
 
     // Variables pour la mesure de distance et de dénivelé
     let measuring = false;
@@ -1168,26 +1169,45 @@ const initializeSelectionMap = (coords) => {
             map.removeLayer(polygonPreview);
             polygonPreview = null;
         }
-        if (polygonPoints.length >= 3) {
-            polygonPreview = L.polygon(polygonPoints, { color: '#c62828', weight: 2, fillOpacity: 0.1, interactive: false }).addTo(map);
-        } else if (polygonPoints.length === 2) {
-            polygonPreview = L.polyline(polygonPoints, { color: '#c62828', weight: 2, interactive: false }).addTo(map);
-        } else if (polygonPoints.length === 1) {
-            polygonPreview = L.circleMarker(polygonPoints[0], { radius: 4, color: '#c62828', fillColor: '#c62828', fillOpacity: 1, interactive: false }).addTo(map);
+        polygonMarkers.forEach(m => map.removeLayer(m));
+        polygonMarkers = [];
+
+        polygonPoints.forEach((pt, idx) => {
+            const color = idx === 0 ? '#ff9800' : '#c62828';
+            const marker = L.circleMarker(pt, { radius: 4, color, fillColor: color, fillOpacity: 1, interactive: false }).addTo(map);
+            polygonMarkers.push(marker);
+        });
+
+        if (polygonPoints.length >= 2) {
+            if (polygonPoints.length >= 3) {
+                polygonPreview = L.polygon(polygonPoints, { color: '#c62828', weight: 2, fillOpacity: 0.1, interactive: false }).addTo(map);
+            } else {
+                polygonPreview = L.polyline(polygonPoints, { color: '#c62828', weight: 2, interactive: false }).addTo(map);
+            }
         }
     };
 
-    const onVolumeKey = (e) => {
+    const CLOSE_DISTANCE_PX = 10;
+    const onMapClickPolygon = (e) => {
         if (!polygonDrawing) return;
-        if (e.key === 'AudioVolumeUp' || e.key === 'VolumeUp') {
-            e.preventDefault();
-            polygonPoints.push(map.getCenter());
-            updatePolygonPreview();
-        } else if (e.key === 'AudioVolumeDown' || e.key === 'VolumeDown') {
-            e.preventDefault();
-            polygonPoints.pop();
-            updatePolygonPreview();
+        const latlng = e.latlng;
+        if (polygonPoints.length >= 3) {
+            const first = polygonPoints[0];
+            const d = map.latLngToContainerPoint(first).distanceTo(map.latLngToContainerPoint(latlng));
+            if (d < CLOSE_DISTANCE_PX) {
+                finishPolygonSelection();
+                return;
+            }
         }
+        polygonPoints.push(latlng);
+        updatePolygonPreview();
+    };
+
+    const onMapRightClickPolygon = (e) => {
+        if (!polygonDrawing) return;
+        e.originalEvent.preventDefault();
+        polygonPoints.pop();
+        updatePolygonPreview();
     };
 
     const finishPolygonSelection = () => {
@@ -1195,11 +1215,14 @@ const initializeSelectionMap = (coords) => {
         polygonDrawing = false;
         if (crosshair) crosshair.style.display = 'none';
         if (drawPolygonBtn) drawPolygonBtn.textContent = '🔶 Zone personnalisée';
-        window.removeEventListener('keydown', onVolumeKey);
+        map.off('click', onMapClickPolygon);
+        map.off('contextmenu', onMapRightClickPolygon);
         if (polygonPreview) {
             map.removeLayer(polygonPreview);
             polygonPreview = null;
         }
+        polygonMarkers.forEach(m => map.removeLayer(m));
+        polygonMarkers = [];
         if (polygonPoints.length >= 3) {
             const latlngs = polygonPoints.slice();
             const centroid = centroidOf(latlngs);
@@ -1230,10 +1253,12 @@ const initializeSelectionMap = (coords) => {
         initializeSelectionMap(center);
         polygonDrawing = true;
         polygonPoints = [];
-        setStatus('Placez la cible et appuyez sur Volume + pour ajouter un point.');
-        if (crosshair) crosshair.style.display = 'block';
+        updatePolygonPreview();
+        setStatus('Cliquez pour ajouter des points, clic droit pour annuler le dernier. Cliquez sur le premier point pour terminer.');
+        if (crosshair) crosshair.style.display = 'none';
         if (drawPolygonBtn) drawPolygonBtn.textContent = '✔️ Terminer';
-        window.addEventListener('keydown', onVolumeKey);
+        map.on('click', onMapClickPolygon);
+        map.on('contextmenu', onMapRightClickPolygon);
     };
 
     let obsSearchCircle = null;


### PR DESCRIPTION
## Summary
- add polygonMarkers array for drawing preview markers
- replace volume key handling with click and right-click events
- show first point in orange and close polygon when re-clicked

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874c7df8180832ca1578c2079044b6a