### PR TITLE
Add zoning access in Biblio Patri

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -396,6 +396,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         patrZnieffBtn.textContent = 'Flore Patri & ZNIEFF';
         const obsBtn = L.DomUtil.create('button', 'action-button', container);
         obsBtn.textContent = 'Flore commune';
+        const zonageBtn = L.DomUtil.create('button', 'action-button', container);
+        zonageBtn.textContent = 'Zonage';
+        const resBtn = L.DomUtil.create('button', 'action-button', container);
+        resBtn.textContent = 'Ressources';
+        const gmapsBtn = L.DomUtil.create('button', 'action-button', container);
+        gmapsBtn.textContent = 'Google Maps';
         L.DomEvent.on(patrBtn, 'click', () => {
             map.closePopup();
             showNavigation();
@@ -410,6 +416,18 @@ document.addEventListener('DOMContentLoaded', async () => {
             map.closePopup();
             showNavigation();
             loadObservationsAt({ latitude: latlng.lat, longitude: latlng.lng, ...extra });
+        });
+        L.DomEvent.on(zonageBtn, 'click', () => {
+            map.closePopup();
+            window.open(`contexte.html?lat=${latlng.lat}&lon=${latlng.lng}&action=zonage`, '_blank');
+        });
+        L.DomEvent.on(resBtn, 'click', () => {
+            map.closePopup();
+            window.open(`contexte.html?lat=${latlng.lat}&lon=${latlng.lng}&action=ressources`, '_blank');
+        });
+        L.DomEvent.on(gmapsBtn, 'click', () => {
+            map.closePopup();
+            window.open(`https://www.google.com/maps?q=${latlng.lat},${latlng.lng}`, '_blank');
         });
         L.DomEvent.disableClickPropagation(container);
         L.popup().setLatLng(latlng).setContent(container).openOn(map);

--- a/contexte.js
+++ b/contexte.js
@@ -291,6 +291,22 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     document.getElementById('measure-distance').addEventListener('click', toggleMeasure);
     initializeEnvMap();
+
+    const params = new URLSearchParams(window.location.search);
+    const lat = parseFloat(params.get('lat'));
+    const lon = parseFloat(params.get('lon'));
+    const action = params.get('action');
+    if (!isNaN(lat) && !isNaN(lon)) {
+        const ll = L.latLng(lat, lon);
+        envMap.setView(ll, 13);
+        if (action === 'zonage') {
+            runZonageAt(ll);
+        } else if (action === 'ressources') {
+            runResourcesAt(ll);
+        } else {
+            showChoicePopup(ll);
+        }
+    }
 });
 
 // Fonction pour utiliser la géolocalisation


### PR DESCRIPTION
## Summary
- expose "Zonage", "Ressources" and "Google Maps" options in the Biblio Patri map popup
- allow contexte.html to start directly at a location via new URL parameters

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874d431a20c832c9dc58b5e74913784