### PR TITLE
Fix Biblio Patri popup layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -369,7 +369,8 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
 
 /* Espace dans la fenêtre de choix des analyses */
 .popup-button-container {
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
     gap: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- show the choice popup buttons on two rows

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874deb8c484832cb413ff30c3217dcf