### PR TITLE
Implement linear analysis

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -16,6 +16,7 @@
     <!-- Bibliothèques pour l'export shapefile -->
     <script src="https://unpkg.com/proj4@2.9.0/dist/proj4.js"></script>
     <script src="shapefile.js"></script>
+    <script src="https://unpkg.com/@turf/turf@6.5.0/turf.min.js"></script>
 
     <script defer src="ui.js"></script>
     <script defer src="biblio-patri.js"></script>
@@ -98,6 +99,7 @@
             <div class="button-grid">
                 <button id="use-geolocation-btn" class="action-button">📍 Ma position</button>
                 <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
+                <button id="draw-line-btn" class="action-button">📐 Analyse linéaire</button>
                 <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
                 <button id="toggle-labels-btn" class="action-button">🏷️ Masquer les étiquettes</button>
                 <button id="measure-distance-btn" class="action-button">📏 Mesurer</button>


### PR DESCRIPTION
## Summary
- add Turf.js and linear analysis button to the bibliographic page
- support drawing a line and creating a 300m buffer
- run the same analyses on the generated buffer

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68789a4c7ff8832c8c788ba2bae6e4f7