### PR TITLE
Add Integration tab with embedded ArcGIS app

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -84,6 +84,7 @@
         <div class="tabs">
             <button class="tab" onclick="window.location.href='index.html'">Identification</button>
             <button class="tab active">Biblio Patri</button>
+            <button class="tab" onclick="window.location.href='integration.html'">Intégration</button>
         </div>
     </nav>
     <div id="section-nav" class="section-nav" style="display:none;">

--- a/index.html
+++ b/index.html
@@ -150,6 +150,7 @@
        <div class="tabs">
            <button class="tab active">Identification</button>
            <button class="tab" onclick="window.location.href='biblio-patri.html'">Biblio Patri</button>
+           <button class="tab" onclick="window.location.href='integration.html'">Intégration</button>
        </div>
    </nav>
 

--- a/integration.html
+++ b/integration.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="fr" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Intégration</title>
+    <link rel="manifest" href="manifest.json">
+    <link rel="icon" href="icons/icon-192.png">
+    <link rel="stylesheet" href="style.css">
+    <script defer src="ui.js"></script>
+    <script defer src="sw-register.js"></script>
+</head>
+<body>
+    <nav class="tabs-container">
+        <div class="tabs">
+            <button class="tab" onclick="window.location.href='index.html'">Identification</button>
+            <button class="tab" onclick="window.location.href='biblio-patri.html'">Biblio Patri</button>
+            <button class="tab active">Intégration</button>
+        </div>
+    </nav>
+    <div class="main-content" style="text-align:center;">
+        <iframe width="300" height="200" frameborder="0" scrolling="no" allowfullscreen src="https://arcg.is/1LDzSL0"></iframe>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `integration.html` page that embeds the ArcGIS app in an iframe
- link the new tab from `index.html` and `biblio-patri.html`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b6e67879c832c9f37a98f2d11393d