### PR TITLE
Add integration tab with ArcGIS iframe

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -84,6 +84,7 @@
         <div class="tabs">
             <button class="tab" onclick="window.location.href='index.html'">Identification</button>
             <button class="tab active">Biblio Patri</button>
+            <button class="tab" onclick="window.location.href='integration.html'">Intégration</button>
         </div>
     </nav>
     <div id="section-nav" class="section-nav" style="display:none;">

--- a/index.html
+++ b/index.html
@@ -150,6 +150,7 @@
        <div class="tabs">
            <button class="tab active">Identification</button>
            <button class="tab" onclick="window.location.href='biblio-patri.html'">Biblio Patri</button>
+           <button class="tab" onclick="window.location.href='integration.html'">Intégration</button>
        </div>
    </nav>
 

--- a/integration.html
+++ b/integration.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="fr" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Intégration - Plante App</title>
+    <link rel="manifest" href="manifest.json">
+    <link rel="icon" href="icons/icon-192.png">
+    <link rel="stylesheet" href="style.css">
+    <script defer src="ui.js"></script>
+    <script defer src="sw-register.js"></script>
+</head>
+<body>
+    <nav class="tabs-container">
+        <div class="tabs">
+            <button class="tab" onclick="window.location.href='index.html'">Identification</button>
+            <button class="tab" onclick="window.location.href='biblio-patri.html'">Biblio Patri</button>
+            <button class="tab active">Intégration</button>
+        </div>
+    </nav>
+    <div class="main-content" style="text-align:center;">
+        <iframe width="1080" height="720" frameborder="0" scrolling="no" allowfullscreen src="https://arcg.is/1y14eW0"></iframe>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Intégration tab beside existing navigation
- create `integration.html` to embed the external ArcGIS app via iframe

## Testing
- `./scripts/setup-tests.sh` *(fails: npm install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687b7008f388832c8ff2361082ff3c4d