### PR TITLE
Add Scraping tab and Puppeteer scraping function

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -85,6 +85,7 @@
             <button class="tab" onclick="window.location.href='index.html'">Identification</button>
             <button class="tab active">Biblio Patri</button>
             <button class="tab" onclick="window.location.href='integration.html'">Intégration</button>
+              <button class="tab" onclick="window.location.href='scraping.html'">Scraping</button>
         </div>
     </nav>
     <div id="section-nav" class="section-nav" style="display:none;">

--- a/index.html
+++ b/index.html
@@ -151,6 +151,7 @@
            <button class="tab active">Identification</button>
            <button class="tab" onclick="window.location.href='biblio-patri.html'">Biblio Patri</button>
            <button class="tab" onclick="window.location.href='integration.html'">Intégration</button>
+           <button class="tab" onclick="window.location.href='scraping.html'">Scraping</button>
        </div>
    </nav>
 

--- a/netlify/functions/arcgis-scrape.js
+++ b/netlify/functions/arcgis-scrape.js
@@ -1,0 +1,40 @@
+const puppeteer = require('puppeteer-core');
+
+const ARC_GIS_URL =
+  'https://www.arcgis.com/apps/webappviewer/index.html?id=' +
+  'bece6e542e4c42e0ba9374529c7de44c&center=623474.6438%2C5625419.691%2C102100&scale=577790.554289';
+
+exports.handler = async () => {
+  let browser;
+  try {
+    browser = await puppeteer.connect({
+      browserWSEndpoint: process.env.CHROME_WS_ENDPOINT,
+    });
+
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1280, height: 900 });
+    await page.goto(ARC_GIS_URL, { waitUntil: 'networkidle0', timeout: 60_000 });
+
+    const map = await page.waitForSelector('#map_gc', { timeout: 10_000 });
+    const { x, y, width, height } = await map.boundingBox();
+    await page.mouse.click(x + width / 2, y + height / 2);
+
+    const popupSel = '.esriPopup, .esri-popup, .esri-popup__main, .dijitPopup';
+    await page.waitForSelector(popupSel, { timeout: 2_000 });
+
+    const data = await page.evaluate(sel => {
+      const n = document.querySelector(sel);
+      return n ? n.innerText.trim() : null;
+    }, popupSel);
+
+    return {
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ok: true, data }),
+    };
+  } catch (err) {
+    return { statusCode: 500, body: JSON.stringify({ ok: false, error: err.message }) };
+  } finally {
+    if (browser) await browser.close();
+  }
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "node-fetch": "^2.6.7",
-    "form-data": "^4.0.0"
+    "form-data": "^4.0.0",
+    "puppeteer-core": "^22.7.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/scraping.html
+++ b/scraping.html
@@ -3,24 +3,28 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Intégration</title>
+    <title>Scraping</title>
     <link rel="manifest" href="manifest.json">
     <link rel="icon" href="icons/icon-192.png">
     <link rel="stylesheet" href="style.css">
     <script defer src="ui.js"></script>
     <script defer src="sw-register.js"></script>
+    <script defer src="scraping.js"></script>
 </head>
 <body>
     <nav class="tabs-container">
         <div class="tabs">
             <button class="tab" onclick="window.location.href='index.html'">Identification</button>
             <button class="tab" onclick="window.location.href='biblio-patri.html'">Biblio Patri</button>
-            <button class="tab active">Intégration</button>
-            <button class="tab" onclick="window.location.href='scraping.html'">Scraping</button>
+            <button class="tab" onclick="window.location.href='integration.html'">Intégration</button>
+            <button class="tab active">Scraping</button>
         </div>
     </nav>
-    <div class="main-content" style="text-align:center;">
-        <iframe width="1080" height="720" frameborder="0" scrolling="no" allowfullscreen src="https://arcg.is/1y14eW0"></iframe>
+    <div class="p-6 space-y-4" style="padding:1.5rem;">
+        <button id="run-scrape-btn" class="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50">
+            Lancer le scraping
+        </button>
+        <pre id="scrape-result" class="whitespace-pre-wrap bg-gray-100 p-4 rounded" style="display:none;"></pre>
     </div>
 </body>
 </html>

--- a/scraping.js
+++ b/scraping.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('run-scrape-btn');
+  const pre = document.getElementById('scrape-result');
+
+  btn.addEventListener('click', async () => {
+    btn.disabled = true;
+    btn.textContent = 'Exécution…';
+    pre.style.display = 'none';
+    pre.textContent = '';
+    try {
+      const r = await fetch('/.netlify/functions/arcgis-scrape', { method: 'POST' });
+      const json = await r.json();
+      pre.textContent = JSON.stringify(json, null, 2);
+      pre.style.display = 'block';
+    } catch (e) {
+      pre.textContent = JSON.stringify({ ok: false, error: e.message }, null, 2);
+      pre.style.display = 'block';
+    } finally {
+      btn.disabled = false;
+      btn.textContent = 'Lancer le scraping';
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add Netlify function `arcgis-scrape.js` using `puppeteer-core`
- create `scraping.html` page with button to trigger scraping
- add frontend script `scraping.js`
- link new Scraping tab from existing pages
- include `puppeteer-core` dependency

## Testing
- `npm test` *(fails: jest not installed)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687b720a0a34832c8403805f073c72cb