### PR TITLE
Fix Browserless endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -104,3 +104,7 @@ L.tileLayer('/tiles/{z}/{x}/{y}.png', {
 
 Activez la compression (gzip ou brotli) pour limiter le poids des transferts.
 
+## Scraping
+
+Avant tout lancement local (`netlify dev`) créez un fichier `.env` contenant la variable `CHROME_WS_ENDPOINT` fournie par Browserless. Cette URL permet à la fonction `arcgis-scrape` de se connecter au navigateur distant.
+

--- a/netlify/functions/arcgis-scrape.js
+++ b/netlify/functions/arcgis-scrape.js
@@ -1,4 +1,5 @@
 const puppeteer = require('puppeteer-core');
+require('dotenv').config();
 
 const ARC_GIS_URL =
   'https://www.arcgis.com/apps/webappviewer/index.html?id=' +
@@ -7,9 +8,15 @@ const ARC_GIS_URL =
 exports.handler = async () => {
   let browser;
   try {
-    browser = await puppeteer.connect({
-      browserWSEndpoint: process.env.CHROME_WS_ENDPOINT,
-    });
+    const ws = process.env.CHROME_WS_ENDPOINT;
+    if (!ws) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ ok: false, error: 'CHROME_WS_ENDPOINT not configured' }),
+      };
+    }
+
+    browser = await puppeteer.connect({ browserWSEndpoint: ws });
 
     const page = await browser.newPage();
     await page.setViewport({ width: 1280, height: 900 });


### PR DESCRIPTION
## Summary
- secure usage of CHROME_WS_ENDPOINT in `arcgis-scrape`
- ignore `.env`
- document scraping prerequisites

## Testing
- `bash ./scripts/setup-tests.sh` *(fails: 403 Forbidden to npm registry)*
- `npx netlify dev` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_687b768899b8832caf561a2d34dd506d