### PR TITLE
Handle Browserless endpoint for scraping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -104,3 +104,10 @@ L.tileLayer('/tiles/{z}/{x}/{y}.png', {
 
 Activez la compression (gzip ou brotli) pour limiter le poids des transferts.
 
+## Scraping
+
+Certaines fonctions utilisent Puppeteer pour récupérer des informations sur des
+sites tiers. Avant tout lancement local (`netlify dev`), créez un fichier `.env`
+à la racine et définissez-y `CHROME_WS_ENDPOINT` avec l'URL de votre instance
+Browserless.
+

--- a/netlify/functions/arcgis-scrape.js
+++ b/netlify/functions/arcgis-scrape.js
@@ -1,4 +1,5 @@
 const puppeteer = require('puppeteer-core');
+require('dotenv').config();
 
 const ARC_GIS_URL =
   'https://www.arcgis.com/apps/webappviewer/index.html?id=' +
@@ -7,9 +8,15 @@ const ARC_GIS_URL =
 exports.handler = async () => {
   let browser;
   try {
-    browser = await puppeteer.connect({
-      browserWSEndpoint: process.env.CHROME_WS_ENDPOINT,
-    });
+    const ws = process.env.CHROME_WS_ENDPOINT;
+    if (!ws) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ ok: false, error: 'CHROME_WS_ENDPOINT not configured' }),
+      };
+    }
+
+    browser = await puppeteer.connect({ browserWSEndpoint: ws });
 
     const page = await browser.newPage();
     await page.setViewport({ width: 1280, height: 900 });


### PR DESCRIPTION
## Summary
- require dotenv and verify CHROME_WS_ENDPOINT in `arcgis-scrape`
- ignore local `.env` file
- document Browserless setup in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b768a65a4832c8723f74221655867