### PR TITLE
Fix Browserless endpoint handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+
+.env

--- a/README.md
+++ b/README.md
@@ -104,3 +104,15 @@ L.tileLayer('/tiles/{z}/{x}/{y}.png', {
 
 Activez la compression (gzip ou brotli) pour limiter le poids des transferts.
 
+## Scraping
+
+Avant tout lancement local (`netlify dev`), créez un fichier `.env` contenant
+la variable `CHROME_WS_ENDPOINT` fournie par Browserless :
+
+```bash
+CHROME_WS_ENDPOINT=wss://chrome.browserless.io?token=VOTRE_TOKEN
+```
+
+Cette URL est utilisée par `netlify/functions/arcgis-scrape.js` pour se
+connecter au navigateur distant.
+

--- a/netlify/functions/arcgis-scrape.js
+++ b/netlify/functions/arcgis-scrape.js
@@ -1,4 +1,5 @@
 const puppeteer = require('puppeteer-core');
+require('dotenv').config();
 
 const ARC_GIS_URL =
   'https://www.arcgis.com/apps/webappviewer/index.html?id=' +
@@ -7,9 +8,15 @@ const ARC_GIS_URL =
 exports.handler = async () => {
   let browser;
   try {
-    browser = await puppeteer.connect({
-      browserWSEndpoint: process.env.CHROME_WS_ENDPOINT,
-    });
+    const ws = process.env.CHROME_WS_ENDPOINT;
+    if (!ws) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ ok: false, error: 'CHROME_WS_ENDPOINT not configured' }),
+      };
+    }
+
+    browser = await puppeteer.connect({ browserWSEndpoint: ws });
 
     const page = await browser.newPage();
     await page.setViewport({ width: 1280, height: 900 });


### PR DESCRIPTION
## Summary
- load `.env` in arcgis-scrape function
- check for `CHROME_WS_ENDPOINT` before connecting
- ignore `.env` files
- document scraping setup

## Testing
- `npm install -g netlify-cli` *(fails: 403 Forbidden)*
- `./scripts/setup-tests.sh` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b768c2c30832ca81a3d494e1dff8c