### PR TITLE
Fix Browserless connection for scraping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Poussez le dépôt sur GitHub puis créez un site sur Netlify. Le fichier `netli
 - recherche par trigramme et suggestions via TaxRef Match
 - comparaison d'espèces et synthèse vocale optionnelle
 
+## Scraping
+
+Avant tout lancement local (`netlify dev`) créez un fichier `.env` à la racine
+contenant la clé `CHROME_WS_ENDPOINT` fournie par Browserless.
+
 ## Intégration de la Carte de la Végétation Potentielle
 
 Cette application peut afficher la Carte de la Végétation Potentielle (CVP)

--- a/netlify/functions/arcgis-scrape.js
+++ b/netlify/functions/arcgis-scrape.js
@@ -1,4 +1,5 @@
 const puppeteer = require('puppeteer-core');
+require('dotenv').config();
 
 const ARC_GIS_URL =
   'https://www.arcgis.com/apps/webappviewer/index.html?id=' +
@@ -7,9 +8,15 @@ const ARC_GIS_URL =
 exports.handler = async () => {
   let browser;
   try {
-    browser = await puppeteer.connect({
-      browserWSEndpoint: process.env.CHROME_WS_ENDPOINT,
-    });
+    const ws = process.env.CHROME_WS_ENDPOINT;
+    if (!ws) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ ok: false, error: 'CHROME_WS_ENDPOINT not configured' }),
+      };
+    }
+
+    browser = await puppeteer.connect({ browserWSEndpoint: ws });
 
     const page = await browser.newPage();
     await page.setViewport({ width: 1280, height: 900 });


### PR DESCRIPTION
## Summary
- check `CHROME_WS_ENDPOINT` before launching Puppeteer
- load env vars in `arcgis-scrape` handler
- ignore local `.env`
- document Browserless endpoint requirement

## Testing
- `npx netlify --version` *(fails: 403 Forbidden)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687b7686bfdc832c9c0506cdc8364135