### PR TITLE
Fix scraping when Browserless endpoint missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ Poussez le dépôt sur GitHub puis créez un site sur Netlify. Le fichier `netli
 ## Scraping
 
 Avant tout lancement local (`netlify dev`) créez un fichier `.env` à la racine
-contenant la clé `CHROME_WS_ENDPOINT` fournie par Browserless.
+contenant éventuellement la clé `CHROME_WS_ENDPOINT` fournie par Browserless.
+Si cette variable est absente, un navigateur Chromium sera lancé localement via
+Puppeteer.
 
 ## Intégration de la Carte de la Végétation Potentielle
 

--- a/env.example
+++ b/env.example
@@ -4,3 +4,5 @@
 PLANTNET_API_KEY=
 GEMINI_API_KEY=
 TTS_API_KEY=
+# Optional: remote Chrome WebSocket endpoint. Leave empty to use a local browser
+CHROME_WS_ENDPOINT=

--- a/netlify/functions/arcgis-scrape.js
+++ b/netlify/functions/arcgis-scrape.js
@@ -1,4 +1,5 @@
-const puppeteer = require('puppeteer-core');
+// Use full puppeteer to embed a local Chromium when needed
+const puppeteer = require('puppeteer');
 require('dotenv').config();
 
 const ARC_GIS_URL =
@@ -9,14 +10,11 @@ exports.handler = async () => {
   let browser;
   try {
     const ws = process.env.CHROME_WS_ENDPOINT;
-    if (!ws) {
-      return {
-        statusCode: 500,
-        body: JSON.stringify({ ok: false, error: 'CHROME_WS_ENDPOINT not configured' }),
-      };
+    if (ws) {
+      browser = await puppeteer.connect({ browserWSEndpoint: ws });
+    } else {
+      browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
     }
-
-    browser = await puppeteer.connect({ browserWSEndpoint: ws });
 
     const page = await browser.newPage();
     await page.setViewport({ width: 1280, height: 900 });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "node-fetch": "^2.6.7",
     "form-data": "^4.0.0",
-    "puppeteer-core": "^22.8.0"
+    "puppeteer": "^22.8.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- allow arcgis scraping to launch a local browser if `CHROME_WS_ENDPOINT` is not set
- document the new behaviour in README and env.example
- switch to full puppeteer package

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b790a6fc8832ca5afe49cef9e8711