### PR TITLE
Amélioration du bouton Ressources

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -77,6 +77,12 @@
       }
       .resource-btn:hover { transform: scale(1.05); }
       .resource-icon { width: 40px; height: 40px; margin-bottom: 0.5rem; }
+      .resource-popup {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        align-items: center;
+      }
     </style>
 </head>
 <body>

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -1723,21 +1723,27 @@ const initializeSelectionMap = (coords) => {
 
     const displayResources = (latlng) => {
         const grid = document.getElementById('resources-grid');
-        if (!grid) return;
-        grid.innerHTML = '';
+        if (grid) {
+            grid.innerHTML = '';
+            grid.style.display = 'none';
+        }
+        const container = L.DomUtil.create('div', 'resource-popup');
         Object.values(SERVICES).forEach(s => {
             const url = s.buildUrl(latlng.lat, latlng.lng);
-            const link = document.createElement('a');
-            link.href = url; link.target = '_blank'; link.rel = 'noopener noreferrer';
-            link.className = 'resource-btn';
-            const img = document.createElement('img');
-            img.src = s.icon; img.alt = ''; img.className = 'resource-icon';
-            const span = document.createElement('span');
+            const link = L.DomUtil.create('a', 'resource-btn', container);
+            link.href = url;
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+            const img = L.DomUtil.create('img', 'resource-icon', link);
+            img.src = s.icon;
+            img.alt = '';
+            const span = L.DomUtil.create('span', '', link);
             span.textContent = s.name;
-            link.appendChild(img); link.appendChild(span);
-            grid.appendChild(link);
         });
-        grid.style.display = 'grid';
+        L.popup({ maxWidth: 260 })
+            .setLatLng(latlng)
+            .setContent(container)
+            .openOn(map);
     };
 
     const runResourcesAt = (latlng) => {


### PR DESCRIPTION
## Summary
- afficher les liens externes dans une fenêtre contextuelle directement sur la carte
- définir le style de cette pop-up

## Testing
- `npm test` *(échoue : jest non installé)*
- `npm run lint` *(échoue : configuration ESLint manquante)*

------
https://chatgpt.com/codex/tasks/task_e_687b7aeeacdc832c9a016662557d8b2a