### PR TITLE
Update Puppeteer config to require remote Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Poussez le dépôt sur GitHub puis créez un site sur Netlify. Le fichier `netli
 ## Scraping
 
 Avant tout lancement local (`netlify dev`) créez un fichier `.env` à la racine
-contenant éventuellement la clé `CHROME_WS_ENDPOINT` fournie par Browserless.
-Si cette variable est absente, un navigateur Chromium sera lancé localement via
-Puppeteer.
+contenant la clé `CHROME_WS_ENDPOINT` fournie par Browserless.
+Cette variable est obligatoire : la fonction `arcgis-scrape` se mettra en
+erreur si elle n'est pas définie.
 
 ## Intégration de la Carte de la Végétation Potentielle
 

--- a/env.example
+++ b/env.example
@@ -4,5 +4,5 @@
 PLANTNET_API_KEY=
 GEMINI_API_KEY=
 TTS_API_KEY=
-# Optional: remote Chrome WebSocket endpoint. Leave empty to use a local browser
-CHROME_WS_ENDPOINT=
+# Remote Chrome WebSocket endpoint (Browserless)
+CHROME_WS_ENDPOINT=wss://chrome.browserless.io?token=VOTRE_TOKEN

--- a/netlify/functions/arcgis-scrape.js
+++ b/netlify/functions/arcgis-scrape.js
@@ -1,6 +1,7 @@
-// Use full puppeteer to embed a local Chromium when needed
-const puppeteer = require('puppeteer');
-require('dotenv').config();
+// Connect to a remote Chrome instance without downloading Chromium
+const puppeteer = require('puppeteer-core');
+require('dotenv').config(); // charge .env en dev
+process.env.PUPPETEER_SKIP_DOWNLOAD = 'true';
 
 const ARC_GIS_URL =
   'https://www.arcgis.com/apps/webappviewer/index.html?id=' +
@@ -10,11 +11,13 @@ exports.handler = async () => {
   let browser;
   try {
     const ws = process.env.CHROME_WS_ENDPOINT;
-    if (ws) {
-      browser = await puppeteer.connect({ browserWSEndpoint: ws });
-    } else {
-      browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+    if (!ws) {
+      return {
+        statusCode: 500,
+        body: '{"ok":false,"error":"CHROME_WS_ENDPOINT manquant"}',
+      };
     }
+    browser = await puppeteer.connect({ browserWSEndpoint: ws });
 
     const page = await browser.newPage();
     await page.setViewport({ width: 1280, height: 900 });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "node-fetch": "^2.6.7",
     "form-data": "^4.0.0",
-    "puppeteer": "^22.8.0"
+    "puppeteer-core": "^22.8.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- use `puppeteer-core` in `arcgis-scrape.js`
- connect only when `CHROME_WS_ENDPOINT` is provided
- skip Chromium download
- document the env var in README and env.example
- switch dependency to `puppeteer-core`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b81d5b15c832c97de6be9e2f05049