### PR TITLE
Fix remote Chrome setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ netlify dev
 
 ## Tests
 
-
 Le projet inclut une suite Jest. Pour faciliter l'exécution des tests sur
 toute plateforme, un script est fourni pour installer les dépendances et
 lancer Jest automatiquement :
@@ -78,9 +77,9 @@ Poussez le dépôt sur GitHub puis créez un site sur Netlify. Le fichier `netli
 ## Scraping
 
 Avant tout lancement local (`netlify dev`) créez un fichier `.env` à la racine
-contenant éventuellement la clé `CHROME_WS_ENDPOINT` fournie par Browserless.
-Si cette variable est absente, un navigateur Chromium sera lancé localement via
-Puppeteer.
+contenant la clé `CHROME_WS_ENDPOINT` fournie par Browserless.
+Cette variable est désormais obligatoire : Puppeteer se connecte uniquement à
+ce navigateur distant et n'installe plus Chromium localement.
 
 ## Intégration de la Carte de la Végétation Potentielle
 
@@ -110,4 +109,3 @@ L.tileLayer('/tiles/{z}/{x}/{y}.png', {
 ```
 
 Activez la compression (gzip ou brotli) pour limiter le poids des transferts.
-

--- a/env.example
+++ b/env.example
@@ -4,5 +4,5 @@
 PLANTNET_API_KEY=
 GEMINI_API_KEY=
 TTS_API_KEY=
-# Optional: remote Chrome WebSocket endpoint. Leave empty to use a local browser
-CHROME_WS_ENDPOINT=
+# Remote Chrome WebSocket endpoint
+CHROME_WS_ENDPOINT=wss://chrome.browserless.io?token=VOTRE_TOKEN

--- a/netlify/functions/arcgis-scrape.js
+++ b/netlify/functions/arcgis-scrape.js
@@ -1,6 +1,7 @@
-// Use full puppeteer to embed a local Chromium when needed
-const puppeteer = require('puppeteer');
-require('dotenv').config();
+// Connects to a remote Chrome instance (Browserless)
+const puppeteer = require('puppeteer-core');
+require('dotenv').config(); // charge .env en dev
+process.env.PUPPETEER_SKIP_DOWNLOAD = 'true';
 
 const ARC_GIS_URL =
   'https://www.arcgis.com/apps/webappviewer/index.html?id=' +
@@ -10,11 +11,11 @@ exports.handler = async () => {
   let browser;
   try {
     const ws = process.env.CHROME_WS_ENDPOINT;
-    if (ws) {
-      browser = await puppeteer.connect({ browserWSEndpoint: ws });
-    } else {
-      browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+    if (!ws) {
+      return { statusCode: 500, body: '{"ok":false,"error":"CHROME_WS_ENDPOINT manquant"}' };
     }
+
+    browser = await puppeteer.connect({ browserWSEndpoint: ws });
 
     const page = await browser.newPage();
     await page.setViewport({ width: 1280, height: 900 });
@@ -27,7 +28,7 @@ exports.handler = async () => {
     const popupSel = '.esriPopup, .esri-popup, .esri-popup__main, .dijitPopup';
     await page.waitForSelector(popupSel, { timeout: 2_000 });
 
-    const data = await page.evaluate(sel => {
+    const data = await page.evaluate((sel) => {
       const n = document.querySelector(sel);
       return n ? n.innerText.trim() : null;
     }, popupSel);
@@ -35,7 +36,7 @@ exports.handler = async () => {
     return {
       statusCode: 200,
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ ok: true, data }),
+      body: JSON.stringify({ ok: true, data })
     };
   } catch (err) {
     return { statusCode: 500, body: JSON.stringify({ ok: false, error: err.message }) };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "node-fetch": "^2.6.7",
     "form-data": "^4.0.0",
-    "puppeteer": "^22.8.0"
+    "puppeteer-core": "^22.8.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- use puppeteer-core for the arcgis scraper
- add PUPPETEER_SKIP_DOWNLOAD and check `CHROME_WS_ENDPOINT`
- document new remote Chrome requirement
- update example environment file

## Testing
- `./scripts/setup-tests.sh` *(fails: 403 Forbidden fetching npm packages)*

------
https://chatgpt.com/codex/tasks/task_e_687b81d91dd8832c88b276b091a6ac94