### PR TITLE
Fix remote Chrome requirement for arcgis-scrape

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Poussez le dépôt sur GitHub puis créez un site sur Netlify. Le fichier `netli
 ## Scraping
 
 Avant tout lancement local (`netlify dev`) créez un fichier `.env` à la racine
-contenant éventuellement la clé `CHROME_WS_ENDPOINT` fournie par Browserless.
-Si cette variable est absente, un navigateur Chromium sera lancé localement via
-Puppeteer.
+contenant la clé `CHROME_WS_ENDPOINT` fournie par Browserless.
+Sans cette variable, la fonction de scraping renverra une erreur et Chromium ne
+sera pas téléchargé localement.
 
 ## Intégration de la Carte de la Végétation Potentielle
 

--- a/env.example
+++ b/env.example
@@ -4,5 +4,6 @@
 PLANTNET_API_KEY=
 GEMINI_API_KEY=
 TTS_API_KEY=
-# Optional: remote Chrome WebSocket endpoint. Leave empty to use a local browser
+# Remote Chrome WebSocket endpoint used by the scraping function
+# Example: wss://chrome.browserless.io?token=YOUR_TOKEN
 CHROME_WS_ENDPOINT=

--- a/netlify/functions/arcgis-scrape.js
+++ b/netlify/functions/arcgis-scrape.js
@@ -1,20 +1,20 @@
-// Use full puppeteer to embed a local Chromium when needed
-const puppeteer = require('puppeteer');
-require('dotenv').config();
+// Use puppeteer-core to avoid bundling Chromium
+const puppeteer = require('puppeteer-core');
+require('dotenv').config(); // charge .env en dev
+process.env.PUPPETEER_SKIP_DOWNLOAD = 'true';
 
 const ARC_GIS_URL =
   'https://www.arcgis.com/apps/webappviewer/index.html?id=' +
   'bece6e542e4c42e0ba9374529c7de44c&center=623474.6438%2C5625419.691%2C102100&scale=577790.554289';
 
 exports.handler = async () => {
+  const ws = process.env.CHROME_WS_ENDPOINT;
+  if (!ws) {
+    return { statusCode: 500, body: '{"ok":false,"error":"CHROME_WS_ENDPOINT manquant"}' };
+  }
   let browser;
   try {
-    const ws = process.env.CHROME_WS_ENDPOINT;
-    if (ws) {
-      browser = await puppeteer.connect({ browserWSEndpoint: ws });
-    } else {
-      browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
-    }
+    browser = await puppeteer.connect({ browserWSEndpoint: ws });
 
     const page = await browser.newPage();
     await page.setViewport({ width: 1280, height: 900 });


### PR DESCRIPTION
## Summary
- disable automatic Chromium download
- connect to remote Chrome only
- clarify environment variable usage in README and env example

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687b81d81d04832c838bd0d9b5af4845