### PR TITLE
Ajout popup liens ressources 2x2

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -79,7 +79,7 @@
       .resource-icon { width: 40px; height: 40px; margin-bottom: 0.5rem; }
       .resources-popup {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        grid-template-columns: repeat(2, 1fr);
         gap: 0.5rem;
       }
     </style>

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -1697,7 +1697,7 @@ const initializeSelectionMap = (coords) => {
                 const R = 6378137.0;
                 const x = R * (lon * Math.PI / 180);
                 const y = R * Math.log(Math.tan(Math.PI / 4 + (lat * Math.PI / 180) / 2));
-                const buffer = 1000;
+                const buffer = 4000;
                 return `https://www.arcgis.com/apps/webappviewer/index.html?id=bece6e542e4c42e0ba9374529c7de44c&extent=${x-buffer}%2C${y-buffer}%2C${x+buffer}%2C${y+buffer}%2C102100`;
             }
         },


### PR DESCRIPTION
## Summary
- adapter la pop-up des ressources pour un affichage compact en 2 x 2
- diminuer le zoom de l'outil ArcGIS pour mieux voir la végétation autour du site

## Testing
- `npm test` *(❌ – jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b827629f8832c9d925741b287f387