### PR TITLE
Shrink navigation tab height

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       /* NOUVEAU : Styles pour la navigation par onglets */
       .tabs-container { background: var(--card); box-shadow: 0 2px 4px rgba(0,0,0,0.1); position: sticky; top: 0; z-index: 100; display:flex; align-items:center; justify-content:space-between; }
       .tabs { display: flex; border-bottom: 2px solid var(--border); flex-grow:1; }
-      .tab { flex: 1; padding: 1rem; text-align: center; cursor: pointer; background: none; border: none; font-size: 1rem; color: var(--text); transition: all 0.3s; position: relative; }
+      .tab { flex: 1; padding: 0.5rem; text-align: center; cursor: pointer; background: none; border: none; font-size: 1rem; color: var(--text); transition: all 0.3s; position: relative; }
       .tab:hover { background: rgba(56, 142, 60, 0.1); }
       .tab.active { color: var(--primary); font-weight: 600; }
       .tab.active::after { content: ''; position: absolute; bottom: -2px; left: 0; right: 0; height: 2px; background: var(--primary); }
@@ -41,7 +41,7 @@
       body.home{ display:flex; flex-direction:column; align-items:center; justify-content:flex-start; min-height:100vh; margin:0; text-align:center; overflow-y:auto; }
       body.home .tabs-container { position: fixed; top: 0; left: 0; right: 0; }
       body.home #main-content {
-         margin-top: 40px; /* Espace pour les onglets */
+         margin-top: 32px; /* Espace pour les onglets */
          flex-grow: 1;
          display: flex;
          flex-direction: column;

--- a/style.css
+++ b/style.css
@@ -338,7 +338,7 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
 /* Style pour la navigation principale (issue de l'app cible) */
 .tabs-container { background: var(--card); box-shadow: 0 2px 4px rgba(0,0,0,0.1); position: sticky; top: 0; z-index: 100; display:flex; align-items:center; justify-content:space-between; }
 .tabs { display: flex; border-bottom: 2px solid var(--border); flex-grow:1; }
-.tab { flex: 1; padding: 1rem; text-align: center; cursor: pointer; background: none; border: none; font-size: 1rem; color: var(--text); transition: all 0.3s; position: relative; }
+.tab { flex: 1; padding: 0.5rem; text-align: center; cursor: pointer; background: none; border: none; font-size: 1rem; color: var(--text); transition: all 0.3s; position: relative; }
 .tab:hover { background: rgba(56, 142, 60, 0.1); }
 .tab.active { color: var(--primary); font-weight: 600; }
 .tab.active::after { content: ''; position: absolute; bottom: -2px; left: 0; right: 0; height: 2px; background: var(--primary); }
@@ -392,7 +392,7 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
 
 .nav-tab {
     flex: 1;
-    padding: 0.8rem 1rem;
+    padding: 0.5rem 0.75rem;
     text-align: center;
     cursor: pointer;
     background: none;


### PR DESCRIPTION
## Summary
- make nav tabs shorter by reducing padding
- update page spacing for compact header

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba16da5ac832c82436e7b6f0871e1