### PR TITLE
Swap icons for measurement and line analysis

### DIFF
--- a/biblio-patri.html
+++ b/biblio-patri.html
@@ -104,10 +104,10 @@
             </div>
             <div class="button-grid">
                 <button id="use-geolocation-btn" class="action-button">📍 Ma position</button>
-                <button id="measure-distance-btn" class="action-button">📏 Mesurer</button>
+                <button id="measure-distance-btn" class="action-button">📐 Mesurer</button>
                 <button id="toggle-tracking-btn" class="action-button">⭐ Suivi de position</button>
                 <button id="draw-polygon-btn" class="action-button">🔶 Zone personnalisée</button>
-                <button id="draw-line-btn" class="action-button">📐 Analyse linéaire</button>
+                <button id="draw-line-btn" class="action-button">📏 Analyse linéaire</button>
                 <button id="toggle-labels-btn" class="action-button">🏷️ Masquer les étiquettes</button>
             </div>
         </div>

--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -428,7 +428,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             measurePoints = [];
             profileSamples = [];
             if (profileContainer) profileContainer.style.display = 'none';
-            measureDistanceBtn.textContent = '📏 Mesurer';
+            measureDistanceBtn.textContent = '📐 Mesurer';
         }
     };
 
@@ -1300,7 +1300,7 @@ const initializeSelectionMap = (coords) => {
         if (!lineDrawing) return;
         lineDrawing = false;
         if (crosshair) crosshair.style.display = 'none';
-        if (drawLineBtn) drawLineBtn.textContent = '📐 Analyse linéaire';
+        if (drawLineBtn) drawLineBtn.textContent = '📏 Analyse linéaire';
         map.off('click', onMapClickLine);
         map.off('contextmenu', onMapContextLine);
         map.off('mousedown', onDownLine);


### PR DESCRIPTION
## Summary
- swap the ruler/triangle icons for the `Mesurer` and `Analyse linéaire` buttons

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687baaaebbe8832c9eed1cf34189c126