### PR TITLE
Handle GBIF synonym names

### DIFF
--- a/synonyms.json
+++ b/synonyms.json
@@ -1,0 +1,3 @@
+{
+  "Pentanema helveticum": "Inula helvetica"
+}


### PR DESCRIPTION
## Summary
- load synonym table in `biblio-patri.js`
- look up canonical name for GBIF results
- add simple `synonyms.json` mapping

## Testing
- `npm test` *(fails: Cannot find module './utils/fetch')*

------
https://chatgpt.com/codex/tasks/task_e_687e209cffd8832cb9cbb4169caec7e8