### PR TITLE
Handle GBIF synonyms when mapping patrimonial species

### DIFF
--- a/__tests__/gbif-proxy.test.js
+++ b/__tests__/gbif-proxy.test.js
@@ -18,6 +18,14 @@ describe('gbif-proxy handler', () => {
     expect(res.body).toBe('{"ok":true}');
   });
 
+  test('synonyms endpoint uses taxonKey', async () => {
+    const fetchMock = createMockFetch('{"ok":true}');
+    const handler = loadGbifHandler(fetchMock);
+    const res = await handler({ queryStringParameters: { endpoint: 'synonyms', taxonKey: '123' } });
+    expect(fetchMock).toHaveBeenCalledWith('https://api.gbif.org/v1/species/123/synonyms');
+    expect(res.statusCode).toBe(200);
+  });
+
   test('returns 400 for invalid endpoint', async () => {
     const fetchMock = createMockFetch('{}');
     const handler = loadGbifHandler(fetchMock);

--- a/netlify/functions/gbif-proxy.js
+++ b/netlify/functions/gbif-proxy.js
@@ -1,8 +1,10 @@
 const fetch = require('./utils/fetch');
+const { URL } = require('url');
 
 const ENDPOINTS = {
   match: 'https://api.gbif.org/v1/species/match',
-  search: 'https://api.gbif.org/v1/occurrence/search'
+  search: 'https://api.gbif.org/v1/occurrence/search',
+  synonyms: (id) => `https://api.gbif.org/v1/species/${id}/synonyms`
 };
 
 exports.handler = async function(event) {
@@ -12,9 +14,18 @@ exports.handler = async function(event) {
     return { statusCode: 400, body: 'Invalid or missing endpoint' };
   }
 
-  const url = new URL(ENDPOINTS[endpoint]);
-  for (const [key, value] of Object.entries(params)) {
-    if (key !== 'endpoint') url.searchParams.append(key, value);
+  let url;
+  if (endpoint === 'synonyms') {
+    const id = params.taxonKey;
+    if (!id) {
+      return { statusCode: 400, body: 'Missing taxonKey' };
+    }
+    url = new URL(ENDPOINTS.synonyms(id));
+  } else {
+    url = new URL(ENDPOINTS[endpoint]);
+    for (const [key, value] of Object.entries(params)) {
+      if (key !== 'endpoint') url.searchParams.append(key, value);
+    }
   }
 
   try {

--- a/test-utils.js
+++ b/test-utils.js
@@ -34,12 +34,19 @@ function loadApp(extraCtx = {}) {
 
 function loadHandler(mockFetch) {
   const code = fs.readFileSync('netlify/functions/inpn-proxy.js', 'utf-8');
-  const patched = code.replace(
-    /const fetch = \(\.\.\.args\) => import\("node-fetch"\)\.then\(\(\{default: f\}\) => f\(\.\.\.args\)\);/,
-    'const fetch = (...args) => global.__fetch(...args);'
-  );
+  const patched = code
+    .replace(
+      /const fetch = \(\.\.\.args\) => import\("node-fetch"\)\.then\(\(\{default: f\}\) => f\(\.\.\.args\)\);/,
+      'const fetch = (...args) => global.__fetch(...args);'
+    )
+    .replace(
+      /const fetch = require\(['"]\.\/utils\/fetch['"]\);/,
+      'const fetch = (...args) => global.__fetch(...args);'
+    );
   const context = { require, console, exports: {}, __fetch: mockFetch };
   context.global = context;
+  context.URL = URL;
+  context.global.URL = URL;
   vm.createContext(context);
   vm.runInContext(patched, context);
   return context.exports.handler;
@@ -47,10 +54,15 @@ function loadHandler(mockFetch) {
 
 function loadAuraHandler(mockFetch) {
   const code = fs.readFileSync('netlify/functions/aura-images.js', 'utf-8');
-  const patched = code.replace(
-    /const fetch = \(\.\.\.args\) => import\(['"]node-fetch['"]\)\.then\(\(\{default: f\}\) => f\(\.\.\.args\)\);/,
-    'const fetch = (...args) => global.__fetch(...args);'
-  );
+  const patched = code
+    .replace(
+      /const fetch = \(\.\.\.args\) => import\(['"]node-fetch['"]\)\.then\(\(\{default: f\}\) => f\(\.\.\.args\)\);/,
+      'const fetch = (...args) => global.__fetch(...args);'
+    )
+    .replace(
+      /const fetch = require\(['"]\.\/utils\/fetch['"]\);/,
+      'const fetch = (...args) => global.__fetch(...args);'
+    );
   const context = { require, console, exports: {}, __fetch: mockFetch };
   context.global = context;
   vm.createContext(context);
@@ -60,10 +72,15 @@ function loadAuraHandler(mockFetch) {
 
 function loadGbifHandler(mockFetch) {
   const code = fs.readFileSync('netlify/functions/gbif-proxy.js', 'utf-8');
-  const patched = code.replace(
-    /const fetch = \(\.\.\.args\) => import\("node-fetch"\)\.then\(\(\{default: f\}\) => f\(\.\.\.args\)\);/,
-    'const fetch = (...args) => global.__fetch(...args);'
-  );
+  const patched = code
+    .replace(
+      /const fetch = \(\.\.\.args\) => import\("node-fetch"\)\.then\(\(\{default: f\}\) => f\(\.\.\.args\)\);/,
+      'const fetch = (...args) => global.__fetch(...args);'
+    )
+    .replace(
+      /const fetch = require\(['"]\.\/utils\/fetch['"]\);/,
+      'const fetch = (...args) => global.__fetch(...args);'
+    );
   const context = { require, console, exports: {}, __fetch: mockFetch };
   context.global = context;
   vm.createContext(context);
@@ -82,8 +99,9 @@ function loadApiProxyHandler(mockFetch, env = {}, FormDataCtor = class { getHead
   const code = fs.readFileSync('netlify/functions/api-proxy.js', 'utf-8');
   const patched = code
     .replace("const fetch = require('node-fetch');", 'const fetch = global.__fetch;')
+    .replace(/const fetch = require\(['"]\.\/utils\/fetch['"]\);/, 'const fetch = global.__fetch;')
     .replace("const FormData = require('form-data');", 'const FormData = global.__FormData;');
-  const context = { require, console, exports: {}, __fetch: mockFetch, __FormData: FormDataCtor, process: { env } };
+  const context = { require, console, exports: {}, __fetch: mockFetch, __FormData: FormDataCtor, process: { env }, Buffer };
   context.global = context;
   vm.createContext(context);
   vm.runInContext(patched, context);
@@ -92,10 +110,15 @@ function loadApiProxyHandler(mockFetch, env = {}, FormDataCtor = class { getHead
 
 function loadAnalyzeHandler(mockFetch, env = {}) {
   const code = fs.readFileSync('netlify/functions/analyze-patrimonial-status.js', 'utf-8');
-  const patched = code.replace(
-    /const fetch = \(\.\.\.args\) => import\('node-fetch'\)\.then\(\(\{default: f\}\) => f\(\.\.\.args\)\);/,
-    'const fetch = (...args) => global.__fetch(...args);'
-  );
+  const patched = code
+    .replace(
+      /const fetch = \(\.\.\.args\) => import\('node-fetch'\)\.then\(\(\{default: f\}\) => f\(\.\.\.args\)\);/,
+      'const fetch = (...args) => global.__fetch(...args);'
+    )
+    .replace(
+      /const fetch = require\(['"]\.\/utils\/fetch['"]\);/,
+      'const fetch = (...args) => global.__fetch(...args);'
+    );
   const context = { require, console, exports: {}, __fetch: mockFetch, process: { env } };
   context.global = context;
   vm.createContext(context);


### PR DESCRIPTION
## Summary
- allow gbif-proxy to fetch synonym data
- test synonym endpoint via gbif-proxy
- map GBIF synonyms in biblio-patri to avoid missing patrimonial taxa
- update test helpers to patch new require form and provide global URL/Buffer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e20994b9c832c9b7b7f1368335de9