### PR TITLE
Add backend API service

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,38 @@ L.tileLayer('/tiles/{z}/{x}/{y}.png', {
 
 Activez la compression (gzip ou brotli) pour limiter le poids des transferts.
 
+
+## Déploiement du backend Selenium
+
+Ce backend Python permet de lancer un workflow Selenium à distance.
+Voici un exemple de procédure complète pour l’installer sur une VM Oracle Cloud :
+
+1. **Provisionner la VM** sous Ubuntu 22.04 (image ARM64) et ouvrir le port 80.
+2. **Installer les paquets requis** :
+   ```bash
+   sudo apt update && sudo apt install -y python3.12 python3.12-venv \
+     chromium-browser chromium-chromedriver nginx certbot python3-certbot-nginx
+   ```
+3. **Déployer le code** dans `/home/ubuntu/app` puis installer les dépendances :
+   ```bash
+   python3.12 -m venv venv
+   source venv/bin/activate
+   pip install -r app/requirements.txt
+   ```
+4. **Configurer systemd** avec `etc/systemd/system/selenium-api.service` puis :
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now selenium-api
+   ```
+5. **Activer le reverse proxy Nginx** :
+   ```bash
+   sudo cp etc/nginx/sites-available/selenium /etc/nginx/sites-available/
+   sudo ln -s ../sites-available/selenium /etc/nginx/sites-enabled/
+   sudo nginx -t && sudo systemctl reload nginx
+   ```
+6. **Obtenir le certificat Let’s Encrypt** :
+   ```bash
+   sudo certbot --nginx -d example.com
+   ```
+7. **Tester depuis Netlify** en appelant l’endpoint `/run?lat=45.8&lon=4.8` via
+   la fonction `triggerRun` du front-end.

--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI, BackgroundTasks, HTTPException
+import logging
+from .selenium_workflow import run as selenium_run
+
+logger = logging.getLogger(__name__)
+app = FastAPI()
+
+
+@app.post("/run")
+async def run_endpoint(lat: float, lon: float, background_tasks: BackgroundTasks):
+    """Trigger Selenium workflow as a background task."""
+    try:
+        background_tasks.add_task(selenium_run, lat, lon)
+    except Exception as exc:  # pragma: no cover - runtime errors
+        logger.exception("Failed to schedule Selenium workflow: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to schedule workflow")
+    return {"status": "scheduled"}

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.111
+uvicorn[standard]
+selenium>=4.21
+openpyxl

--- a/app/selenium_workflow.py
+++ b/app/selenium_workflow.py
@@ -1,0 +1,24 @@
+import logging
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+
+logger = logging.getLogger(__name__)
+
+
+def run(lat: float, lon: float) -> None:
+    """Launch the Selenium workflow using provided coordinates."""
+    options = Options()
+    options.add_argument("--headless=new")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    driver = webdriver.Chrome(options=options)
+    try:
+        url = f"https://www.geoportail.gouv.fr/carte?c={lon},{lat}&z=10"
+        logger.info("Opening %s", url)
+        driver.get(url)
+        driver.save_screenshot("/tmp/selenium_workflow.png")
+        logger.info("Screenshot saved")
+    except Exception as exc:  # pragma: no cover - runtime errors
+        logger.exception("Workflow failed: %s", exc)
+    finally:
+        driver.quit()

--- a/etc/nginx/sites-available/selenium
+++ b/etc/nginx/sites-available/selenium
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name example.com;
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name example.com;
+
+    ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/etc/systemd/system/selenium-api.service
+++ b/etc/systemd/system/selenium-api.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Selenium API Service
+After=network.target
+
+[Service]
+User=ubuntu
+WorkingDirectory=/home/ubuntu/app
+ExecStart=/usr/bin/python3 -m uvicorn app.api:app --host 0.0.0.0 --port 8000
+Restart=always
+EnvironmentFile=/etc/environment
+
+[Install]
+WantedBy=multi-user.target

--- a/frontend/src/services/seleniumApi.js
+++ b/frontend/src/services/seleniumApi.js
@@ -1,0 +1,14 @@
+export async function triggerRun(lat, lon) {
+  const url = `/run?lat=${encodeURIComponent(lat)}&lon=${encodeURIComponent(lon)}`;
+  try {
+    const response = await fetch(url, { method: 'POST' });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || `HTTP ${response.status}`);
+    }
+    return await response.json();
+  } catch (err) {
+    console.error('Error triggering Selenium workflow:', err);
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- create selenium workflow helper and FastAPI app
- add requirements for backend
- add systemd service and nginx config
- provide frontend helper to trigger the backend
- document VM provisioning steps

## Testing
- `./scripts/setup-tests.sh` *(fails: `npm ci` can only install packages when package.json and package-lock.json are out of sync)*

------
https://chatgpt.com/codex/tasks/task_e_687e975cab4c832c984e11d4d255b17d