### PR TITLE
Fix PDF extraction range

### DIFF
--- a/app.js
+++ b/app.js
@@ -475,7 +475,7 @@ window.handleFloraGallicaClick = async function(event, pdfFile, startPage) {
             .sort((a, b) => a - b);
         let endPage = totalPages;
         for (const p of pages) {
-            if (p > startPage) { endPage = p - 1; break; }
+            if (p > startPage) { endPage = p; break; }
         }
 
         const newDoc = await PDFDocument.create();


### PR DESCRIPTION
## Summary
- adjust end page calculation when extracting Flora Gallica pages so that the first page of the next genus is included

## Testing
- `npm test` *(fails: Cannot find module './utils/fetch')*

------
https://chatgpt.com/codex/tasks/task_e_6884e4325c2c832ca9805fb17cf5b9a7