### PR TITLE
Include next genus page in Flora Gallica extracts

### DIFF
--- a/app.js
+++ b/app.js
@@ -475,7 +475,11 @@ window.handleFloraGallicaClick = async function(event, pdfFile, startPage) {
             .sort((a, b) => a - b);
         let endPage = totalPages;
         for (const p of pages) {
-            if (p > startPage) { endPage = p - 1; break; }
+            if (p > startPage) {
+                // Include the first page of the following genus
+                endPage = p;
+                break;
+            }
         }
 
         const newDoc = await PDFDocument.create();


### PR DESCRIPTION
## Summary
- adjust the PDF split logic so the first page of the next genus is kept when generating a Flora Gallica extract

## Testing
- `npm test` *(fails: Cannot find module './utils/fetch')*

------
https://chatgpt.com/codex/tasks/task_e_6884e4342edc832c8cd0371a67945c46