### PR TITLE
Improve Flora Gallica PDF quality

### DIFF
--- a/app.js
+++ b/app.js
@@ -483,7 +483,10 @@ window.handleFloraGallicaClick = async function(event, pdfFile, startPage) {
             const [pg] = await newDoc.copyPages(srcDoc, [p - 1]);
             newDoc.addPage(pg);
         }
-        const newBytes = await newDoc.save();
+        const newBytes = await newDoc.save({
+            useObjectStreams: false,
+            compress: false
+        });
         const url = URL.createObjectURL(new Blob([newBytes], { type: 'application/pdf' }));
         window.open(`viewer.html?file=${encodeURIComponent(url)}`, '_blank');
     } catch (err) {


### PR DESCRIPTION
## Summary
- avoid recompression when saving Flora Gallica excerpts

## Testing
- `npm test` *(fails: Cannot find module './utils/fetch')*

------
https://chatgpt.com/codex/tasks/task_e_6884e6fe9130832ca46dc1a5d435daad