### PR TITLE
Improve Flora Gallica PDF extraction quality

### DIFF
--- a/app.js
+++ b/app.js
@@ -483,7 +483,7 @@ window.handleFloraGallicaClick = async function(event, pdfFile, startPage) {
             const [pg] = await newDoc.copyPages(srcDoc, [p - 1]);
             newDoc.addPage(pg);
         }
-        const newBytes = await newDoc.save();
+        const newBytes = await newDoc.save({ useObjectStreams: false });
         const url = URL.createObjectURL(new Blob([newBytes], { type: 'application/pdf' }));
         window.open(`viewer.html?file=${encodeURIComponent(url)}`, '_blank');
     } catch (err) {

--- a/assets/viewer_app.js
+++ b/assets/viewer_app.js
@@ -12,7 +12,8 @@ try {
 
 const viewerContainer = document.getElementById('pdf-viewer');
 const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
-const RENDER_SCALE = isIOS ? 1.8 : 2.0;
+// Increase render scale for sharper display of extracted PDFs
+const RENDER_SCALE = isIOS ? 2.4 : 3.0;
 
 /**
  * Affiche un message d'erreur et un lien de secours.


### PR DESCRIPTION
## Summary
- save extracted PDFs without object streams
- render PDF viewer at a higher scale for sharper text

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6884e7035978832cbc97b754be0e2c0c