### PR TITLE
Fix PDF quality when exporting Flora Gallica excerpts

### DIFF
--- a/app.js
+++ b/app.js
@@ -483,7 +483,11 @@ window.handleFloraGallicaClick = async function(event, pdfFile, startPage) {
             const [pg] = await newDoc.copyPages(srcDoc, [p - 1]);
             newDoc.addPage(pg);
         }
-        const newBytes = await newDoc.save();
+        // Sauvegarde sans recompression pour préserver la qualité
+        const newBytes = await newDoc.save({
+            useObjectStreams: false,
+            addDefaultPage: false
+        });
         const url = URL.createObjectURL(new Blob([newBytes], { type: 'application/pdf' }));
         window.open(`viewer.html?file=${encodeURIComponent(url)}`, '_blank');
     } catch (err) {


### PR DESCRIPTION
## Summary
- improve PDF generation quality by disabling recompression when saving

## Testing
- `npm test` *(fails: Cannot find module './utils/fetch')*


------
https://chatgpt.com/codex/tasks/task_e_6884e7049bc8832c9fa6b2c5f1938543