### PR TITLE
Implement OCR export for Flora Gallica sub‑PDFs

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -7,6 +7,7 @@
     <link rel="manifest" href="manifest.json">
     <link rel="icon" href="icons/icon-192.png">
     <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4.0.2/dist/tesseract.min.js"></script>
     <script defer src="ui.js"></script>
     <script defer src="app.js"></script>
     <script defer src="compare-page.js"></script>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
    <link rel="manifest" href="manifest.json">
    <link rel="icon" href="icons/icon-192.png">
    <script src="assets/pdf-lib.min.js"></script>
+   <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4.0.2/dist/tesseract.min.js"></script>
    <script defer src="ui.js"></script>
    <script defer src="app.js"></script>
    <script defer src="sw-register.js"></script>

--- a/organ.html
+++ b/organ.html
@@ -9,6 +9,7 @@
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon-192.png">
   <script src="assets/pdf-lib.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4.0.2/dist/tesseract.min.js"></script>
   <script defer src="ui.js"></script>
   <script defer src="app.js"></script>
   <script defer src="sw-register.js"></script>


### PR DESCRIPTION
## Summary
- add Tesseract.js in pages using `app.js`
- implement `ocrPdfToText` and text download helpers
- run OCR when generating Flora Gallica excerpts

## Testing
- `npm test` *(fails: Cannot find module './utils/fetch' from 'test-utils.js')*

------
https://chatgpt.com/codex/tasks/task_e_6884ebbed0f8832cae4f62a408f4e83e