### PR TITLE
Enable optional OCR for Flora Gallica excerpts

### DIFF
--- a/viewer.html
+++ b/viewer.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Visualiseur - Flora Gallica</title>
     <link rel="stylesheet" href="style.css">
+    <script src="https://unpkg.com/tesseract.js@5.0.1/dist/tesseract.min.js"></script>
     <style>
         body, html {
             margin: 0;
@@ -54,7 +55,9 @@
     </style>
 </head>
 <body>
-
+    <div style="text-align:center;margin:1rem;">
+        <button id="ocr-btn" class="action-button">Extraction OCR</button>
+    </div>
     <div id="pdf-viewer">
         </div>
 


### PR DESCRIPTION
## Summary
- open Flora Gallica excerpts in internal viewer
- download generated excerpt PDF automatically
- add OCR button in viewer to trigger optional text extraction
- support OCR extraction in viewer with Tesseract

## Testing
- `npx eslint -c .eslintrc.json .` *(fails: Module "file:///workspace/FloreApp/.eslintrc.json?mtime=... needs an import attribute of type "json")*
- `npm test` *(fails to locate './utils/fetch' module)*

------
https://chatgpt.com/codex/tasks/task_e_688501f0776c832ca643e88a82ff9976